### PR TITLE
fix: pin skiasharp to jellyfin host version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,18 @@ updates:
         patterns:
           - "*Analyzer*"
           - "StyleCop.*"
-      skiasharp:
-        patterns:
-          - "SkiaSharp*"
+    # SkiaSharp's runtime is supplied by the Jellyfin host, so the
+    # plugin's reference must EXACTLY match Jellyfin's pinned version
+    # per ABI (see comment in Jellyfin.Plugin.Harmonie.csproj). We
+    # never want Dependabot to bump these — bumps cause the plugin
+    # DLL to fail to load with status NotSupported on hosts that ship
+    # an older SkiaSharp. When Jellyfin itself bumps, we bump
+    # manually in the same PR that updates the Jellyfin.Controller
+    # version. SkiaSharp.HarfBuzz and the NativeAssets.* siblings are
+    # included so the family stays in lockstep.
+    ignore:
+      - dependency-name: "SkiaSharp"
+      - dependency-name: "SkiaSharp.*"
 
   # Keep workflow Action versions current (e.g. actions/checkout@v4 → v5).
   - package-ecosystem: github-actions

--- a/Jellyfin.Plugin.Harmonie/Jellyfin.Plugin.Harmonie.csproj
+++ b/Jellyfin.Plugin.Harmonie/Jellyfin.Plugin.Harmonie.csproj
@@ -38,19 +38,29 @@
   </ItemGroup>
 
   <!--
-    SkiaSharp is used to render the playlist cover images. Versions are
-    matched to the Jellyfin host's Directory.Packages.props per ABI; we
-    exclude runtime assets so the host's loaded copy is used at runtime
-    (same pattern as Jellyfin.Controller). No native libs ship with the
-    plugin.
+    SkiaSharp is used to render the playlist cover images. Versions
+    MUST exactly match the Jellyfin host's Directory.Packages.props
+    per ABI; mismatches make the plugin DLL fail to load at runtime
+    (Jellyfin reports "NotSupported"). We exclude runtime assets so
+    the host's loaded copy is used at runtime — same pattern as
+    Jellyfin.Controller. No native libs ship with the plugin.
+
+    DO NOT bump these unless Jellyfin itself bumps SkiaSharp first.
+    Dependabot is configured to ignore SkiaSharp* updates for this
+    reason. Verify the host version against the upstream release tag
+    before changing:
+    https://github.com/jellyfin/jellyfin/blob/v10.10.7/Directory.Packages.props
+    https://github.com/jellyfin/jellyfin/blob/v10.11.8/Directory.Packages.props
   -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <!-- Matches Jellyfin 10.10.x. -->
     <PackageReference Include="SkiaSharp" Version="2.88.9">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="SkiaSharp" Version="3.119.2">
+    <!-- Matches Jellyfin 10.11.x. -->
+    <PackageReference Include="SkiaSharp" Version="3.116.1">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/tests/Jellyfin.Plugin.Harmonie.Tests/Jellyfin.Plugin.Harmonie.Tests.csproj
+++ b/tests/Jellyfin.Plugin.Harmonie.Tests/Jellyfin.Plugin.Harmonie.Tests.csproj
@@ -27,8 +27,8 @@
       package and must be declared explicitly so CI on Ubuntu can find
       libSkiaSharp.so.
     -->
-    <PackageReference Include="SkiaSharp" Version="3.119.2" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.2" />
+    <PackageReference Include="SkiaSharp" Version="3.116.1" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Reverts SkiaSharp from `3.119.2` back to `3.116.1` for the net9.0 ABI, both in the plugin csproj and the test csproj. Adds a Dependabot `ignore` rule covering all `SkiaSharp*` packages. Strengthens the warning comment so the next person doesn't rubber-stamp a future Dependabot bump.