### PR TITLE
fix: stop playlist growing on every refresh

### DIFF
--- a/Jellyfin.Plugin.Harmonie/Services/PlaylistAutoRefreshService.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/PlaylistAutoRefreshService.cs
@@ -46,7 +46,7 @@ public sealed class PlaylistAutoRefreshService : IHostedService
 
     // Last-seen ordered child guids per playlist. Used by the polling
     // task to detect reorders that didn't surface as ItemUpdated events.
-    private readonly Dictionary<Guid, IReadOnlyList<Guid>> _lastSeenOrder = new();
+    private readonly Dictionary<Guid, IReadOnlyList<string>> _lastSeenOrder = new();
     private readonly object _orderLock = new();
 
     // Last-seen name per playlist. Used to recognise a rename event so
@@ -244,7 +244,7 @@ public sealed class PlaylistAutoRefreshService : IHostedService
     private void CheckPlaylistForChange(Playlist playlist)
     {
         var current = SnapshotChildren(playlist);
-        IReadOnlyList<Guid>? previous;
+        IReadOnlyList<string>? previous;
         lock (_orderLock)
         {
             _lastSeenOrder.TryGetValue(playlist.Id, out previous);
@@ -305,23 +305,34 @@ public sealed class PlaylistAutoRefreshService : IHostedService
         }
     }
 
-    private static IReadOnlyList<Guid> SnapshotChildren(Playlist playlist)
+    /// <summary>
+    /// Captures the playlist's current child list as an ordered
+    /// sequence of paths. <c>LinkedChild.Path</c> is set by
+    /// <c>LinkedChild.Create</c> and is stable across metadata
+    /// refreshes; <c>LinkedChild.ItemId</c> is reset to null on every
+    /// metadata refresh by <c>Folder.RefreshLinkedChildren</c> and
+    /// can't be used as a stable identity. Children whose Path is
+    /// null or empty (rare; would indicate a corrupt entry) are
+    /// dropped from the snapshot — those are inert from a "did the
+    /// playlist change" perspective.
+    /// </summary>
+    private static IReadOnlyList<string> SnapshotChildren(Playlist playlist)
     {
         if (playlist.LinkedChildren is null)
         {
-            return Array.Empty<Guid>();
+            return Array.Empty<string>();
         }
 
-        var ids = new List<Guid>(playlist.LinkedChildren.Length);
+        var paths = new List<string>(playlist.LinkedChildren.Length);
         foreach (var child in playlist.LinkedChildren)
         {
-            if (child.ItemId is { } id)
+            if (!string.IsNullOrEmpty(child.Path))
             {
-                ids.Add(id);
+                paths.Add(child.Path);
             }
         }
 
-        return ids;
+        return paths;
     }
 
     /// <summary>
@@ -377,7 +388,7 @@ public sealed class PlaylistAutoRefreshService : IHostedService
         }
     }
 
-    private static bool OrderEquals(IReadOnlyList<Guid> a, IReadOnlyList<Guid> b)
+    private static bool OrderEquals(IReadOnlyList<string> a, IReadOnlyList<string> b)
     {
         if (a.Count != b.Count)
         {
@@ -386,7 +397,7 @@ public sealed class PlaylistAutoRefreshService : IHostedService
 
         for (var i = 0; i < a.Count; i++)
         {
-            if (a[i] != b[i])
+            if (!string.Equals(a[i], b[i], StringComparison.Ordinal))
             {
                 return false;
             }

--- a/Jellyfin.Plugin.Harmonie/Services/PlaylistContentReplacer.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/PlaylistContentReplacer.cs
@@ -1,43 +1,59 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+#if NET8_0
+using Jellyfin.Data.Enums;
+#else
+using Jellyfin.Data.Enums;
+#endif
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Playlists;
 
 namespace Jellyfin.Plugin.Harmonie.Services;
 
 /// <summary>
-/// Wipes a playlist's existing entries and adds a new ordered list.
-/// Encapsulates two pieces of knowledge:
+/// Replaces a playlist's contents in one shot by overwriting
+/// <c>Playlist.LinkedChildren</c> with a fresh array of
+/// <see cref="LinkedChild"/> entries and persisting via
+/// <see cref="BaseItem.UpdateToRepositoryAsync"/>. Avoids
+/// <see cref="IPlaylistManager.RemoveItemFromPlaylistAsync"/>, which
+/// matches existing children by <c>ItemId</c> — a field that
+/// <c>Folder.RefreshLinkedChildren</c> explicitly resets to null on
+/// every metadata refresh. After our cover-regen refresh runs, every
+/// linked child has <c>ItemId == null</c>, the manager's filter
+/// matches nothing, and "remove" silently no-ops, leaving the
+/// playlist to grow by N items per refresh.
 ///
-///   1. Removal keys are <c>LinkedChild.ItemId</c> formatted as a hex
-///      "N" GUID, NOT <c>LibraryItemId</c>. <c>LibraryItemId</c> is
-///      only set when the linked child has no on-disk path, so for
-///      regular tracks it's null and removals would silently no-op.
-///   2. The <see cref="IPlaylistManager.RemoveItemFromPlaylistAsync"/>
-///      overload takes the playlist id as a string while the
-///      <see cref="IPlaylistManager.AddItemToPlaylistAsync"/> overload
-///      takes a Guid. Easy to flip when copy-pasting.
-///
-/// Both kinds of refresh (prefix-mode and per-user style) need exactly
-/// this behaviour, so the implementation lives in one place.
+/// <para>
+/// Writing <c>LinkedChildren</c> directly is also what
+/// <c>IPlaylistManager.MoveItemAsync</c> and other internal Jellyfin
+/// playlist mutations end up doing; we just skip the
+/// dedup/ownership wrapping because we control the input list.
+/// </para>
 /// </summary>
 public class PlaylistContentReplacer
 {
-    private readonly IPlaylistManager _playlistManager;
+    private readonly ILibraryManager _libraryManager;
 
-    public PlaylistContentReplacer(IPlaylistManager playlistManager)
+    public PlaylistContentReplacer(ILibraryManager libraryManager)
     {
-        _playlistManager = playlistManager;
+        _libraryManager = libraryManager;
     }
 
     /// <summary>
-    /// Removes every existing entry from the playlist, then adds the
-    /// supplied items in order. Empty <paramref name="newItems"/> is
-    /// allowed and just leaves the playlist empty.
+    /// Overwrites the playlist's linked children with the supplied
+    /// items in order. Empty <paramref name="newItems"/> leaves the
+    /// playlist empty.
     /// </summary>
+    /// <param name="playlist">Playlist to mutate.</param>
+    /// <param name="ownerId">Reserved for parity with the previous
+    /// signature; unused now that we bypass <see cref="IPlaylistManager"/>.</param>
+    /// <param name="newItems">Ordered list of audio item ids to set
+    /// as the playlist's contents.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     public async Task ReplaceContentsAsync(
         Playlist playlist,
         Guid ownerId,
@@ -47,26 +63,26 @@ public class PlaylistContentReplacer
         ArgumentNullException.ThrowIfNull(playlist);
         ArgumentNullException.ThrowIfNull(newItems);
 
-        var existingEntryIds = playlist.LinkedChildren
-            .Where(c => c.ItemId.HasValue)
-            .Select(c => c.ItemId!.Value.ToString("N", CultureInfo.InvariantCulture))
-            .ToList();
-
-        if (existingEntryIds.Count > 0)
-        {
-            await _playlistManager
-                .RemoveItemFromPlaylistAsync(
-                    playlist.Id.ToString("N", CultureInfo.InvariantCulture),
-                    existingEntryIds)
-                .ConfigureAwait(false);
-        }
-
-        if (newItems.Count > 0)
+        // Resolve each item to its BaseItem so LinkedChild.Create can
+        // capture the Path. Items we can't resolve are dropped silently
+        // (typically already deleted from the library between resolve
+        // time and now).
+        var newChildren = new List<LinkedChild>(newItems.Count);
+        foreach (var id in newItems)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await _playlistManager
-                .AddItemToPlaylistAsync(playlist.Id, newItems, ownerId)
-                .ConfigureAwait(false);
+            var item = _libraryManager.GetItemById(id);
+            if (item is null)
+            {
+                continue;
+            }
+
+            newChildren.Add(LinkedChild.Create(item));
         }
+
+        playlist.LinkedChildren = newChildren.ToArray();
+        await playlist
+            .UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, cancellationToken)
+            .ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
Generated playlists were growing by N tracks every refresh and re-triggering themselves every 5s.

**Fix.**
- `PlaylistContentReplacer` bypasses `IPlaylistManager.RemoveItemFromPlaylistAsync`: resolve ids to `BaseItem`s, build `LinkedChild`, overwrite `playlist.LinkedChildren`, persist with `UpdateToRepositoryAsync(MetadataEdit)`. Constructor takes `ILibraryManager` now.
- `SnapshotChildren` indexes by `LinkedChild.Path` (stable) instead of `ItemId`.
