### PR TITLE
feat: add [HARMONIE] index playlist + auto-refresh QOL

### DIFF
--- a/Jellyfin.Plugin.Harmonie/HarmonieApi/Dtos.cs
+++ b/Jellyfin.Plugin.Harmonie/HarmonieApi/Dtos.cs
@@ -263,6 +263,73 @@ public class VibePlaylistRequest
 }
 
 /// <summary>
+/// One row in <c>GET /api/v1/genres</c>. A "genre" is the left side of
+/// a Discogs <c>Genre---Style</c> label (<c>Electronic</c>,
+/// <c>Hip Hop</c>, ...).
+/// </summary>
+public class GenreEnumeration
+{
+    [JsonPropertyName("genre")]
+    public string Genre { get; set; } = string.Empty;
+
+    [JsonPropertyName("track_count")]
+    public int TrackCount { get; set; }
+
+    [JsonPropertyName("style_count")]
+    public int StyleCount { get; set; }
+
+    [JsonPropertyName("mean_probability")]
+    public double MeanProbability { get; set; }
+
+    [JsonPropertyName("max_probability")]
+    public double MaxProbability { get; set; }
+}
+
+/// <summary>
+/// Wrapper for the <c>GET /api/v1/genres</c> response.
+/// </summary>
+public class GenreList
+{
+    [JsonPropertyName("items")]
+    public List<GenreEnumeration> Items { get; set; } = new();
+
+    [JsonPropertyName("total")]
+    public int Total { get; set; }
+}
+
+/// <summary>
+/// One row in <c>GET /api/v1/styles</c>. A "style" is the right side
+/// of a Discogs <c>Genre---Style</c> label (<c>House</c>,
+/// <c>Hard Techno</c>, ...).
+/// </summary>
+public class StyleEnumeration
+{
+    [JsonPropertyName("style")]
+    public string Style { get; set; } = string.Empty;
+
+    [JsonPropertyName("track_count")]
+    public int TrackCount { get; set; }
+
+    [JsonPropertyName("mean_probability")]
+    public double MeanProbability { get; set; }
+
+    [JsonPropertyName("max_probability")]
+    public double MaxProbability { get; set; }
+}
+
+/// <summary>
+/// Wrapper for the <c>GET /api/v1/styles</c> response.
+/// </summary>
+public class StyleList
+{
+    [JsonPropertyName("items")]
+    public List<StyleEnumeration> Items { get; set; } = new();
+
+    [JsonPropertyName("total")]
+    public int Total { get; set; }
+}
+
+/// <summary>
 /// Subset of harmonie's <c>GET /api/v1/status</c> response. Combines
 /// what used to be split across <c>/info</c> and <c>/stats</c>; the
 /// plugin renders all of it on the config page so users can see the

--- a/Jellyfin.Plugin.Harmonie/HarmonieApi/HarmonieClient.cs
+++ b/Jellyfin.Plugin.Harmonie/HarmonieApi/HarmonieClient.cs
@@ -215,6 +215,47 @@ public class HarmonieClient
         => PostPlaylistAsync(request, ct);
 
     /// <summary>
+    /// Lists the top-level genres in harmonie's library. The
+    /// <c>[HARMONIE]</c> index playlist uses this.
+    /// </summary>
+    public async Task<GenreList> ListGenresAsync(CancellationToken ct)
+    {
+        var config = RequireConfig();
+
+        using var req = NewRequest(HttpMethod.Get, "/api/v1/genres", config);
+        using var resp = await SendAsync(req, config, ct).ConfigureAwait(false);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content
+            .ReadFromJsonAsync<GenreList>(JsonOptions, ct)
+            .ConfigureAwait(false) ?? new GenreList();
+    }
+
+    /// <summary>
+    /// Lists styles present in harmonie's library, optionally scoped
+    /// to one genre branch. Pass <paramref name="genre"/> to only
+    /// return styles under that genre.
+    /// </summary>
+    public async Task<StyleList> ListStylesAsync(string? genre, CancellationToken ct)
+    {
+        var config = RequireConfig();
+
+        var path = "/api/v1/styles";
+        if (!string.IsNullOrEmpty(genre))
+        {
+            var qs = HttpUtility.ParseQueryString(string.Empty);
+            qs["genre"] = genre;
+            path = path + "?" + qs;
+        }
+
+        using var req = NewRequest(HttpMethod.Get, path, config);
+        using var resp = await SendAsync(req, config, ct).ConfigureAwait(false);
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content
+            .ReadFromJsonAsync<StyleList>(JsonOptions, ct)
+            .ConfigureAwait(false) ?? new StyleList();
+    }
+
+    /// <summary>
     /// Resolves a single harmonie track by tags and/or path via
     /// <c>GET /api/v1/tracks/resolve</c>. Returns null on 404.
     /// </summary>

--- a/Jellyfin.Plugin.Harmonie/Services/Cover/HarmoniePlaylistImageProvider.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/Cover/HarmoniePlaylistImageProvider.cs
@@ -160,6 +160,7 @@ public class HarmoniePlaylistImageProvider : IDynamicImageProvider
         HarmonieMode.Mix => "MIX",
         HarmonieMode.Style => "STYLE",
         HarmonieMode.Genre => "GENRE",
+        HarmonieMode.Index => "HARMONIE",
         _ => "HARMONIE",
     };
 

--- a/Jellyfin.Plugin.Harmonie/Services/HarmoniePlaylistFilter.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/HarmoniePlaylistFilter.cs
@@ -33,7 +33,8 @@ internal static class HarmoniePlaylistFilter
     /// managed and rebuilt on its own schedule, so user edits to its
     /// body don't apply. STYLE and GENRE are also plugin-managed: their
     /// content is a vibe-mode query result, the user only changes the
-    /// filter by renaming the playlist.
+    /// filter by renaming the playlist. HARMONIE is an empty index
+    /// playlist; its body is irrelevant.
     /// </summary>
     public static bool IsWatched(Playlist playlist)
     {
@@ -41,6 +42,7 @@ internal static class HarmoniePlaylistFilter
         return options is not null
             && options.Mode != HarmonieMode.Mix
             && options.Mode != HarmonieMode.Style
-            && options.Mode != HarmonieMode.Genre;
+            && options.Mode != HarmonieMode.Genre
+            && options.Mode != HarmonieMode.Index;
     }
 }

--- a/Jellyfin.Plugin.Harmonie/Services/PlaylistAutoRefreshService.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/PlaylistAutoRefreshService.cs
@@ -73,9 +73,78 @@ public sealed class PlaylistAutoRefreshService : IHostedService
         _libraryManager.ItemUpdated += OnItemUpdated;
         _prefixService.RefreshCompleted += OnPrefixRefreshCompleted;
         _started = true;
+
+        // Snapshot every existing Harmonie playlist's current state
+        // before we listen for any events. Without this baseline,
+        // the first ItemUpdated event after startup compares "primed"
+        // (no previous snapshot) and we skip it — which means a
+        // rename done after the most recent restart goes unobserved
+        // until the next daily refresh task. The first-sight cost is
+        // one library walk; cheap.
+        PrimeSnapshotsFromLibrary();
+
         _logger.LogInformation(
             "Harmonie auto-refresh observer attached (event-driven; reorder polling runs as a scheduled task).");
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Walks every Harmonie-prefixed playlist on the server once and
+    /// records its current name and ordered child paths. Establishes
+    /// the baseline against which subsequent <c>ItemUpdated</c>
+    /// events are compared.
+    /// </summary>
+    private void PrimeSnapshotsFromLibrary()
+    {
+        try
+        {
+            var primed = 0;
+            foreach (var playlist in EnumerateHarmoniePlaylists())
+            {
+                RecordSnapshot(playlist);
+                primed++;
+            }
+
+            if (primed > 0)
+            {
+                _logger.LogDebug(
+                    "Primed snapshots for {Count} Harmonie playlist(s) at startup.",
+                    primed);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Snapshot priming is a "best effort" startup task. If it
+            // fails (library not yet ready, transient DB error), we
+            // fall back to the per-event prime path — a minor
+            // regression to "first event after restart misses" but
+            // not a hard failure.
+            _logger.LogDebug(ex, "Failed to prime snapshots at startup.");
+        }
+    }
+
+    private IEnumerable<Playlist> EnumerateHarmoniePlaylists()
+    {
+        var query = new InternalItemsQuery
+        {
+            IncludeItemTypes = new[] { BaseItemKind.Playlist },
+            Recursive = true,
+        };
+
+        foreach (var item in _libraryManager.GetItemList(query))
+        {
+            if (item is not Playlist playlist)
+            {
+                continue;
+            }
+
+            if (HarmoniePlaylistFilter.TryGetOptions(playlist) is null)
+            {
+                continue;
+            }
+
+            yield return playlist;
+        }
     }
 
     public Task StopAsync(CancellationToken cancellationToken)

--- a/Jellyfin.Plugin.Harmonie/Services/PlaylistAutoRefreshService.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/PlaylistAutoRefreshService.cs
@@ -239,7 +239,7 @@ public sealed class PlaylistAutoRefreshService : IHostedService
         }
 
         var change = DetectChangesAndSnapshot(playlist);
-        if (!change.Renamed && !change.OrderChanged)
+        if (!change.FirstSight && !change.Renamed && !change.OrderChanged)
         {
             _logger.LogDebug(
                 "Skipping {Reason} for {Name} (no name/order change since last snapshot).",
@@ -249,19 +249,22 @@ public sealed class PlaylistAutoRefreshService : IHostedService
         }
 
         _logger.LogInformation(
-            "Saw {Reason} for {Name} (id={Id}, children={Count}, renamed={Renamed}, orderChanged={OrderChanged})",
+            "Saw {Reason} for {Name} (id={Id}, children={Count}, firstSight={FirstSight}, renamed={Renamed}, orderChanged={OrderChanged})",
             e.UpdateReason,
             playlist.Name,
             playlist.Id,
             playlist.LinkedChildren?.Length ?? 0,
+            change.FirstSight,
             change.Renamed,
             change.OrderChanged);
 
-        // Renames are single user actions with no follow-up burst, so
-        // there's nothing to coalesce — fire immediately. Track-add
-        // and reorder events still go through the debounce so a
-        // drag-drop of N tracks doesn't kick off N refreshes.
-        var delay = change.Renamed ? TimeSpan.Zero : DebounceDelay;
+        // Discrete events (a rename, or first time we've seen this
+        // playlist as Harmonie) fire immediately — no follow-up burst
+        // to coalesce. Track-add/reorder events still go through the
+        // debounce so a drag-drop of N tracks doesn't kick off N
+        // refreshes.
+        var immediate = change.FirstSight || change.Renamed;
+        var delay = immediate ? TimeSpan.Zero : DebounceDelay;
         ScheduleRefresh(playlist.Id, playlist.Name, delay);
     }
 
@@ -410,35 +413,50 @@ public sealed class PlaylistAutoRefreshService : IHostedService
     }
 
     /// <summary>
-    /// Reads the playlist's current (name, ordered child list),
-    /// compares each against the last snapshot under their respective
-    /// locks, and updates both snapshots to the current values. The
-    /// first time a playlist is seen there is nothing to compare
-    /// against — both fields are reported as "unchanged" and only the
-    /// snapshot is primed, so a fresh server start doesn't fire a
-    /// burst of refreshes for already-existing playlists.
+    /// Compares the playlist's current name and ordered child paths
+    /// against the last snapshot under their respective locks, then
+    /// updates the snapshot to the current values.
+    ///
+    /// <para>
+    /// Returns three flags. <c>FirstSight</c> means we had no
+    /// baseline for this playlist (newly Harmonie-renamed, or missed
+    /// by startup priming). <c>Renamed</c> means we had a baseline
+    /// and the name differs. <c>OrderChanged</c> means the ordered
+    /// child paths differ. The caller decides what to do based on
+    /// the combination — see <see cref="OnItemUpdated"/> for the
+    /// dispatch rules.
+    /// </para>
     /// </summary>
-    private (bool Renamed, bool OrderChanged) DetectChangesAndSnapshot(Playlist playlist)
+    private (bool FirstSight, bool Renamed, bool OrderChanged) DetectChangesAndSnapshot(
+        Playlist playlist)
     {
         var currentName = playlist.Name ?? string.Empty;
-        bool renamed;
+        bool hadName, renamed;
         lock (_nameLock)
         {
-            renamed = _lastSeenName.TryGetValue(playlist.Id, out var previous)
-                && !string.Equals(previous, currentName, StringComparison.Ordinal);
+            hadName = _lastSeenName.TryGetValue(playlist.Id, out var previousName);
+            renamed = hadName
+                && !string.Equals(previousName, currentName, StringComparison.Ordinal);
             _lastSeenName[playlist.Id] = currentName;
         }
 
         var currentOrder = SnapshotChildren(playlist);
-        bool orderChanged;
+        bool hadOrder, orderChanged;
         lock (_orderLock)
         {
-            orderChanged = _lastSeenOrder.TryGetValue(playlist.Id, out var previous)
-                && !OrderEquals(previous, currentOrder);
+            hadOrder = _lastSeenOrder.TryGetValue(playlist.Id, out var previousOrder);
+            orderChanged = hadOrder && !OrderEquals(previousOrder!, currentOrder);
             _lastSeenOrder[playlist.Id] = currentOrder;
         }
 
-        return (renamed, orderChanged);
+        // First sight = no baseline at all. Either the playlist was
+        // just renamed *into* a Harmonie prefix from a non-Harmonie
+        // name (so PrimeSnapshotsFromLibrary skipped it), or the
+        // priming pass at startup missed it for some other reason.
+        // Either way, treat it as a discrete "fill this" event.
+        var firstSight = !hadName || !hadOrder;
+
+        return (firstSight, renamed, orderChanged);
     }
 
     /// <summary>

--- a/Jellyfin.Plugin.Harmonie/Services/PrefixPlaylistOptions.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/PrefixPlaylistOptions.cs
@@ -45,22 +45,33 @@ public enum HarmonieMode
     /// <c>Genre---Style</c>) — e.g. "Electronic", "Hip Hop".
     /// </summary>
     Genre,
+
+    /// <summary>
+    /// <c>[HARMONIE]</c>. An index playlist that stays empty. The
+    /// plugin writes the list of genres and styles harmonie has
+    /// indexed into the playlist's <c>Overview</c> field, so the
+    /// playlist detail page becomes a browsable catalog of names a
+    /// user can plug into <see cref="Genre"/> or <see cref="Style"/>
+    /// playlists.
+    /// </summary>
+    Index,
 }
 
 /// <summary>
 /// Parses a Jellyfin playlist name into a strongly-typed options object.
-/// The plugin recognises five fixed prefixes:
+/// The plugin recognises six fixed prefixes:
 ///
-///   [RADIO] — similar-mode radio, seeded by user-added tracks.
-///   [DRIFT] — drifting walk, seeded by one user-added track.
-///   [MIX]   — listen-history mix, no manual seeding.
-///   [STYLE] — vibe playlist filtered to one Discogs style.
-///   [GENRE] — vibe playlist filtered to one Discogs genre.
+///   [RADIO]    — similar-mode radio, seeded by user-added tracks.
+///   [DRIFT]    — drifting walk, seeded by one user-added track.
+///   [MIX]      — listen-history mix, no manual seeding.
+///   [STYLE]    — vibe playlist filtered to one Discogs style.
+///   [GENRE]    — vibe playlist filtered to one Discogs genre.
+///   [HARMONIE] — index playlist; lists genres/styles in the overview.
 ///
-/// For [RADIO]/[DRIFT]/[MIX], anything after the closing bracket is a
-/// human-readable label and is ignored by the parser. For
-/// [STYLE]/[GENRE] the post-bracket text is the filter value — the
-/// playlist <c>[GENRE] Hip Hop</c> filters on genre "Hip Hop".
+/// For [RADIO]/[DRIFT]/[MIX]/[HARMONIE], anything after the closing
+/// bracket is a human-readable label and is ignored by the parser.
+/// For [STYLE]/[GENRE] the post-bracket text is the filter value —
+/// the playlist <c>[GENRE] Hip Hop</c> filters on genre "Hip Hop".
 ///
 /// Optional tokens inside the brackets after the mode word, separated
 /// by spaces. The set of accepted tokens depends on the mode.
@@ -72,7 +83,7 @@ public enum HarmonieMode
 ///   drift              use harmonie's drift mode for expansion (mix only).
 ///   style_min=&lt;f&gt;   minimum classifier probability (style/genre only).
 ///
-/// Returns null if the name doesn't open with one of the five prefixes.
+/// Returns null if the name doesn't open with one of the six prefixes.
 /// </summary>
 public class PrefixPlaylistOptions
 {
@@ -81,6 +92,7 @@ public class PrefixPlaylistOptions
     public const string MixPrefix = "[MIX]";
     public const string StylePrefix = "[STYLE]";
     public const string GenrePrefix = "[GENRE]";
+    public const string IndexPrefix = "[HARMONIE]";
 
     private static readonly Regex BracketPattern = new(
         @"^\[(?<word>[A-Za-z]+)(?<rest>[^\]]*)\]",
@@ -178,6 +190,10 @@ public class PrefixPlaylistOptions
         else if (string.Equals(bracketWord, "GENRE", StringComparison.OrdinalIgnoreCase))
         {
             mode = HarmonieMode.Genre;
+        }
+        else if (string.Equals(bracketWord, "HARMONIE", StringComparison.OrdinalIgnoreCase))
+        {
+            mode = HarmonieMode.Index;
         }
         else
         {

--- a/Jellyfin.Plugin.Harmonie/Services/PrefixPlaylistService.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/PrefixPlaylistService.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Enums;
@@ -223,6 +225,15 @@ public class PrefixPlaylistService
         {
             await RefreshVibePlaylistAsync(playlist, owner, options, pathMapper, config, ct)
                 .ConfigureAwait(false);
+            return;
+        }
+
+        // [HARMONIE] is an index playlist: it stays empty, and its
+        // Overview is populated with the catalog of genres and styles
+        // harmonie has indexed. Nothing else like the other modes.
+        if (options.Mode == HarmonieMode.Index)
+        {
+            await RefreshHarmonieIndexPlaylistAsync(playlist, owner, ct).ConfigureAwait(false);
             return;
         }
 
@@ -551,6 +562,136 @@ public class PrefixPlaylistService
             result.Items.Count);
 
         _coverRefresh.Queue(playlist.Id);
+    }
+
+    /// <summary>
+    /// Builds a <c>[HARMONIE]</c> index playlist: an empty playlist
+    /// whose <c>Overview</c> is set to a human-readable list of every
+    /// genre and style harmonie has indexed, separated by <c>&lt;br&gt;</c>.
+    /// Users open the playlist on any client to see the catalog of
+    /// names they can plug into a <c>[GENRE] X</c> or <c>[STYLE] Y</c>
+    /// playlist.
+    /// </summary>
+    private async Task RefreshHarmonieIndexPlaylistAsync(
+        Playlist playlist,
+        User owner,
+        CancellationToken ct)
+    {
+        GenreList genres;
+        StyleList styles;
+        try
+        {
+            // Sequential, not parallel — harmonie is local on most
+            // setups and the responses are tiny. Keeping it serial
+            // simplifies error handling.
+            genres = await _client.ListGenresAsync(ct).ConfigureAwait(false);
+            styles = await _client.ListStylesAsync(genre: null, ct).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Playlist {Name}: failed to fetch genre/style index from harmonie.",
+                playlist.Name);
+            return;
+        }
+
+        var overview = BuildHarmonieIndexOverview(genres, styles);
+
+        lock (_refreshingLock)
+        {
+            _refreshing.Add(playlist.Id);
+        }
+
+        try
+        {
+            // 1. Wipe any tracks the user might have added — index
+            //    playlists stay empty, the catalog lives in Overview.
+            await _contentReplacer
+                .ReplaceContentsAsync(playlist, owner.Id, Array.Empty<Guid>(), ct)
+                .ConfigureAwait(false);
+
+            // 2. Update the Overview field with the freshly built list.
+            //    UpdateToRepositoryAsync(MetadataEdit) persists the
+            //    change and surfaces it in the UI.
+            playlist.Overview = overview;
+            await playlist
+                .UpdateToRepositoryAsync(ItemUpdateType.MetadataEdit, ct)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            // See note in RefreshOneAsync's finally — fire the event
+            // while IsCurrentlyRefreshing still gates downstream events.
+            RefreshCompleted?.Invoke(this, new PlaylistRefreshedEventArgs(playlist));
+            lock (_refreshingLock)
+            {
+                _refreshing.Remove(playlist.Id);
+            }
+        }
+
+        _logger.LogInformation(
+            "Refreshed playlist {Name} (HARMONIE index): {Genres} genres, {Styles} styles.",
+            playlist.Name,
+            genres.Items.Count,
+            styles.Items.Count);
+
+        _coverRefresh.Queue(playlist.Id);
+    }
+
+    /// <summary>
+    /// Renders the catalog of genres and styles as a single string
+    /// using <c>&lt;br&gt;</c> as the line separator. Jellyfin's
+    /// overview renderer collapses literal newlines into one paragraph,
+    /// so we need explicit break tags to get a list.
+    /// </summary>
+    public static string BuildHarmonieIndexOverview(GenreList genres, StyleList styles)
+    {
+        ArgumentNullException.ThrowIfNull(genres);
+        ArgumentNullException.ThrowIfNull(styles);
+
+        var sb = new StringBuilder();
+        const string Br = "<br>";
+        const string Para = "<br><br>";
+
+        sb.Append("Genres in your library:").Append(Br);
+        foreach (var g in genres.Items)
+        {
+            sb.Append(WebUtility.HtmlEncode(g.Genre))
+                .Append(" (")
+                .Append(g.TrackCount.ToString("N0", CultureInfo.InvariantCulture))
+                .Append(" tracks)")
+                .Append(Br);
+        }
+
+        if (genres.Items.Count == 0)
+        {
+            sb.Append("(none — has harmonie scanned your library yet?)").Append(Br);
+        }
+
+        sb.Append(Para);
+
+        sb.Append("Styles in your library:").Append(Br);
+        foreach (var s in styles.Items)
+        {
+            sb.Append(WebUtility.HtmlEncode(s.Style))
+                .Append(" (")
+                .Append(s.TrackCount.ToString("N0", CultureInfo.InvariantCulture))
+                .Append(" tracks)")
+                .Append(Br);
+        }
+
+        if (styles.Items.Count == 0)
+        {
+            sb.Append("(none)").Append(Br);
+        }
+
+        sb.Append(Para);
+        sb.Append(
+            "Name a playlist [GENRE] Electronic or [STYLE] House to fill it with " +
+            "tracks from that genre or style.");
+
+        return sb.ToString();
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The plugin's settings page shows live harmonie scan progress and counters.
 
 ## Use it
 
-Make a normal Jellyfin playlist and prefix the name with `[RADIO]`, `[DRIFT]`, `[MIX]`, `[STYLE]`, or `[GENRE]`. The plugin watches for edits and refreshes the playlist in the background five seconds later.
+Make a normal Jellyfin playlist and prefix the name with `[RADIO]`, `[DRIFT]`, `[MIX]`, `[STYLE]`, `[GENRE]`, or `[HARMONIE]`. The plugin watches for edits and refreshes the playlist in the background five seconds later.
 
 Radio playlists treat the first N tracks as seeds (N is configurable, default 5). The first seed is the strongest anchor. Drag a track into the top to make it a seed; remove it to demote it.
 
@@ -68,6 +68,8 @@ Drift playlists take one seed (the first track) and walk away from it in chunks.
 Mix playlists seed themselves from your Jellyfin listening history, so you don't add tracks. Anything you do add gets wiped on the next refresh. The default is "today's mix" from the last week.
 
 Style and genre playlists fill themselves with 100 tracks (default, configurable) of one Discogs style or genre — the part of the name after the closing bracket is the filter value. `[GENRE] Hip Hop` returns 100 hip-hop tracks; `[STYLE] House` returns 100 house tracks across every genre. Each refresh shuffles the matching pool fresh, so the playlist feels different every day. Anything you add gets wiped.
+
+A `[HARMONIE]` playlist is a discovery aid: it stays empty, but its description lists every genre and style harmonie has indexed in your library, with track counts. Open it in any Jellyfin client to see the catalog of names you can plug into a `[GENRE] X` or `[STYLE] Y` playlist. Refreshes on the daily task.
 
 You can override settings per playlist with tokens inside the brackets:
 

--- a/tests/Jellyfin.Plugin.Harmonie.Tests/HarmonieIndexOverviewTests.cs
+++ b/tests/Jellyfin.Plugin.Harmonie.Tests/HarmonieIndexOverviewTests.cs
@@ -1,0 +1,81 @@
+using Jellyfin.Plugin.Harmonie.HarmonieApi;
+using Jellyfin.Plugin.Harmonie.Services;
+using Xunit;
+
+namespace Jellyfin.Plugin.Harmonie.Tests;
+
+/// <summary>
+/// The Overview string is what the user sees on a <c>[HARMONIE]</c>
+/// playlist. Jellyfin renders it in a single paragraph and collapses
+/// real newlines, so the format relies on literal <c>&lt;br&gt;</c>
+/// tags between entries — pin that down here.
+/// </summary>
+public class HarmonieIndexOverviewTests
+{
+    [Fact]
+    public void Builds_overview_with_br_separators_and_track_counts()
+    {
+        var genres = new GenreList
+        {
+            Items =
+            {
+                new GenreEnumeration { Genre = "Electronic", TrackCount = 1234 },
+                new GenreEnumeration { Genre = "Hip Hop", TrackCount = 567 },
+            },
+        };
+        var styles = new StyleList
+        {
+            Items =
+            {
+                new StyleEnumeration { Style = "House", TrackCount = 432 },
+            },
+        };
+
+        var overview = PrefixPlaylistService.BuildHarmonieIndexOverview(genres, styles);
+
+        // Each genre and style entry is separated by <br>.
+        Assert.Contains("Electronic (1,234 tracks)<br>", overview);
+        Assert.Contains("Hip Hop (567 tracks)<br>", overview);
+        Assert.Contains("House (432 tracks)<br>", overview);
+
+        // Sections are split with <br><br>.
+        Assert.Contains("<br><br>", overview);
+
+        // The footer hints at how to use the catalog.
+        Assert.Contains("[GENRE]", overview);
+        Assert.Contains("[STYLE]", overview);
+    }
+
+    [Fact]
+    public void Empty_genres_and_styles_produce_a_well_formed_overview()
+    {
+        // The user might be running the plugin against a not-yet-
+        // scanned harmonie. Don't crash, don't render an empty list
+        // unannounced — explain what's going on.
+        var overview = PrefixPlaylistService.BuildHarmonieIndexOverview(
+            new GenreList(),
+            new StyleList());
+
+        Assert.Contains("(none — has harmonie scanned your library yet?)", overview);
+        Assert.Contains("(none)", overview);
+    }
+
+    [Fact]
+    public void Genre_and_style_names_are_html_escaped()
+    {
+        // Discogs labels are unlikely to contain HTML, but the
+        // overview is rendered as HTML by Jellyfin so an unsanitised
+        // name would inject markup. Pin the safe behaviour down.
+        var genres = new GenreList
+        {
+            Items = { new GenreEnumeration { Genre = "<script>", TrackCount = 1 } },
+        };
+
+        var overview = PrefixPlaylistService.BuildHarmonieIndexOverview(
+            genres,
+            new StyleList());
+
+        Assert.Contains("&lt;script&gt;", overview);
+        Assert.DoesNotContain("<script>", overview);
+    }
+}

--- a/tests/Jellyfin.Plugin.Harmonie.Tests/PrefixPlaylistOptionsTests.cs
+++ b/tests/Jellyfin.Plugin.Harmonie.Tests/PrefixPlaylistOptionsTests.cs
@@ -343,4 +343,35 @@ public class PrefixPlaylistOptionsTests
         Assert.Null(PrefixPlaylistOptions.TryParse("[DRIFT] Long Mix")!.FilterValue);
         Assert.Null(PrefixPlaylistOptions.TryParse("[MIX] Today")!.FilterValue);
     }
+
+    // ---------------------------------------------------------------
+    // Index mode ([HARMONIE]).
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void Bare_harmonie_prefix_yields_index_mode()
+    {
+        var opts = PrefixPlaylistOptions.TryParse("[HARMONIE]");
+        Assert.NotNull(opts);
+        Assert.Equal(HarmonieMode.Index, opts!.Mode);
+        Assert.Null(opts.FilterValue);
+    }
+
+    [Fact]
+    public void Harmonie_prefix_match_is_case_insensitive()
+    {
+        Assert.Equal(HarmonieMode.Index, PrefixPlaylistOptions.TryParse("[harmonie]")!.Mode);
+        Assert.Equal(HarmonieMode.Index, PrefixPlaylistOptions.TryParse("[Harmonie]")!.Mode);
+    }
+
+    [Fact]
+    public void Harmonie_prefix_ignores_post_bracket_text_as_label_only()
+    {
+        // Index mode has no filter value; trailing text is just a
+        // human-readable label, parsed but not used.
+        var opts = PrefixPlaylistOptions.TryParse("[HARMONIE] My Music Index");
+        Assert.NotNull(opts);
+        Assert.Equal(HarmonieMode.Index, opts!.Mode);
+        Assert.Null(opts.FilterValue);
+    }
 }


### PR DESCRIPTION
Adds the `[HARMONIE]` index playlist plus a couple of auto-refresh QOL fixes that surfaced while testing it.