### PR TITLE
feat: persist playback checkpoints

### DIFF
--- a/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/ListeningActivityModels.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/ListeningActivityModels.cs
@@ -80,6 +80,29 @@ internal sealed record ListeningActivityEvent(
     string? DeviceId);
 
 /// <summary>
+/// Latest durable state for a playback that has not produced a stop event.
+/// One session has one row per participating user.
+/// </summary>
+internal sealed record PlaybackSessionCheckpoint(
+    string SessionKey,
+    Guid UserId,
+    Guid ItemId,
+    DateTimeOffset? StartedUtc,
+    DateTimeOffset LastObservedUtc,
+    long? StartPositionTicks,
+    long? EndPositionTicks,
+    long? MaxPositionTicks,
+    long? ActiveListenTicks,
+    int SeekForwardCount,
+    int SeekBackwardCount,
+    int PauseCount,
+    bool IsPaused,
+    long? DurationTicks,
+    string? PlaySessionId,
+    string? ClientName,
+    string? DeviceId);
+
+/// <summary>
 /// Administrative information about the listening database.
 /// </summary>
 public sealed class ListeningActivityStatus

--- a/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/ListeningActivityStore.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/ListeningActivityStore.cs
@@ -433,6 +433,35 @@ public sealed class ListeningActivityStore
         }
     }
 
+    /// <summary>
+    /// Reads the durable state of an unfinished session so an evicted
+    /// in-memory session can resume where it left off. Any user's row works:
+    /// the playback metrics are identical across a session's rows.
+    /// </summary>
+    internal PlaybackSessionCheckpoint? TryGetPlaybackSession(string sessionKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionKey);
+        lock (_sync)
+        {
+            using var connection = _database.OpenConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText = """
+                SELECT
+                    session_key, user_id, item_id, started_utc,
+                    last_observed_utc, start_position_ticks, end_position_ticks,
+                    max_position_ticks, active_listen_ticks, seek_forward_count,
+                    seek_backward_count, pause_count, is_paused, duration_ticks,
+                    play_session_id, client_name, device_id
+                FROM playback_sessions
+                WHERE session_key = $session_key
+                LIMIT 1;
+                """;
+            command.Parameters.AddWithValue("$session_key", sessionKey);
+            using var reader = command.ExecuteReader();
+            return reader.Read() ? ReadCheckpoint(reader) : null;
+        }
+    }
+
     internal int RecoverAbandonedPlaybackSessions(DateTimeOffset observedBeforeUtc)
     {
         lock (_sync)
@@ -549,33 +578,41 @@ public sealed class ListeningActivityStore
         var checkpoints = new List<PlaybackSessionCheckpoint>();
         while (reader.Read())
         {
-            if (!Guid.TryParseExact(reader.GetString(1), "N", out var userId)
-                || !Guid.TryParseExact(reader.GetString(2), "N", out var itemId))
+            if (ReadCheckpoint(reader) is { } checkpoint)
             {
-                continue;
+                checkpoints.Add(checkpoint);
             }
-
-            checkpoints.Add(new PlaybackSessionCheckpoint(
-                reader.GetString(0),
-                userId,
-                itemId,
-                ReadDate(reader, 3),
-                ReadDate(reader, 4) ?? DateTimeOffset.MinValue,
-                ReadLong(reader, 5),
-                ReadLong(reader, 6),
-                ReadLong(reader, 7),
-                ReadLong(reader, 8),
-                reader.GetInt32(9),
-                reader.GetInt32(10),
-                reader.GetInt32(11),
-                reader.GetInt32(12) != 0,
-                ReadLong(reader, 13),
-                ReadString(reader, 14),
-                ReadString(reader, 15),
-                ReadString(reader, 16)));
         }
 
         return checkpoints;
+    }
+
+    private static PlaybackSessionCheckpoint? ReadCheckpoint(SqliteDataReader reader)
+    {
+        if (!Guid.TryParseExact(reader.GetString(1), "N", out var userId)
+            || !Guid.TryParseExact(reader.GetString(2), "N", out var itemId))
+        {
+            return null;
+        }
+
+        return new PlaybackSessionCheckpoint(
+            reader.GetString(0),
+            userId,
+            itemId,
+            ReadDate(reader, 3),
+            ReadDate(reader, 4) ?? DateTimeOffset.MinValue,
+            ReadLong(reader, 5),
+            ReadLong(reader, 6),
+            ReadLong(reader, 7),
+            ReadLong(reader, 8),
+            reader.GetInt32(9),
+            reader.GetInt32(10),
+            reader.GetInt32(11),
+            reader.GetInt32(12) != 0,
+            ReadLong(reader, 13),
+            ReadString(reader, 14),
+            ReadString(reader, 15),
+            ReadString(reader, 16));
     }
 
     private static void WritePlayback(

--- a/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/ListeningActivityStore.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/ListeningActivityStore.cs
@@ -355,6 +355,112 @@ public sealed class ListeningActivityStore
         return result;
     }
 
+    internal void UpsertPlaybackSessions(
+        IReadOnlyList<PlaybackSessionCheckpoint> checkpoints)
+    {
+        ArgumentNullException.ThrowIfNull(checkpoints);
+        if (checkpoints.Count == 0)
+        {
+            return;
+        }
+
+        lock (_sync)
+        {
+            using var connection = _database.OpenConnection();
+            using var transaction = connection.BeginTransaction();
+            foreach (var checkpoint in checkpoints)
+            {
+                using var command = connection.CreateCommand();
+                command.Transaction = transaction;
+                command.CommandText = """
+                    INSERT INTO playback_sessions (
+                        session_key, user_id, item_id, started_utc,
+                        last_observed_utc, start_position_ticks,
+                        end_position_ticks, max_position_ticks,
+                        active_listen_ticks, seek_forward_count,
+                        seek_backward_count, pause_count, is_paused,
+                        duration_ticks, play_session_id, client_name, device_id)
+                    VALUES (
+                        $session_key, $user_id, $item_id, $started_utc,
+                        $last_observed_utc, $start_position_ticks,
+                        $end_position_ticks, $max_position_ticks,
+                        $active_listen_ticks, $seek_forward_count,
+                        $seek_backward_count, $pause_count, $is_paused,
+                        $duration_ticks, $play_session_id, $client_name, $device_id)
+                    ON CONFLICT (session_key, user_id) DO UPDATE SET
+                        item_id = excluded.item_id,
+                        started_utc = excluded.started_utc,
+                        last_observed_utc = excluded.last_observed_utc,
+                        start_position_ticks = excluded.start_position_ticks,
+                        end_position_ticks = excluded.end_position_ticks,
+                        max_position_ticks = excluded.max_position_ticks,
+                        active_listen_ticks = excluded.active_listen_ticks,
+                        seek_forward_count = excluded.seek_forward_count,
+                        seek_backward_count = excluded.seek_backward_count,
+                        pause_count = excluded.pause_count,
+                        is_paused = excluded.is_paused,
+                        duration_ticks = excluded.duration_ticks,
+                        play_session_id = excluded.play_session_id,
+                        client_name = excluded.client_name,
+                        device_id = excluded.device_id;
+                    """;
+                AddCheckpointParameters(command, checkpoint);
+                command.ExecuteNonQuery();
+            }
+
+            transaction.Commit();
+        }
+    }
+
+    internal void CompletePlaybackSession(
+        string sessionKey,
+        IReadOnlyList<ListeningActivityEvent> activities)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionKey);
+        ArgumentNullException.ThrowIfNull(activities);
+
+        lock (_sync)
+        {
+            using var connection = _database.OpenConnection();
+            using var transaction = connection.BeginTransaction();
+            foreach (var activity in activities)
+            {
+                WritePlayback(connection, transaction, activity);
+            }
+
+            DeletePlaybackSession(connection, transaction, sessionKey);
+            transaction.Commit();
+        }
+    }
+
+    internal int RecoverAbandonedPlaybackSessions(DateTimeOffset observedBeforeUtc)
+    {
+        lock (_sync)
+        {
+            using var connection = _database.OpenConnection();
+            using var transaction = connection.BeginTransaction();
+            var checkpoints = ReadPlaybackSessions(
+                connection,
+                transaction,
+                observedBeforeUtc);
+            foreach (var checkpoint in checkpoints)
+            {
+                WritePlayback(
+                    connection,
+                    transaction,
+                    PlaybackSessionAccumulator.Recover(checkpoint));
+                DeletePlaybackSession(
+                    connection,
+                    transaction,
+                    checkpoint.SessionKey,
+                    checkpoint.UserId);
+            }
+
+            transaction.Commit();
+            return checkpoints.Count;
+        }
+    }
+
     internal void RecordPlayback(ListeningActivityEvent activity)
     {
         ArgumentNullException.ThrowIfNull(activity);
@@ -362,40 +468,9 @@ public sealed class ListeningActivityStore
         lock (_sync)
         {
             using var connection = _database.OpenConnection();
-            using var command = connection.CreateCommand();
-            command.CommandText = """
-                INSERT INTO playback_events (
-                    user_id, item_id, started_utc, stopped_utc,
-                    start_position_ticks, end_position_ticks, max_position_ticks,
-                    active_listen_ticks, seek_forward_count, seek_backward_count,
-                    pause_count, is_early_skip, duration_ticks, played_to_completion,
-                    counted_as_play, play_session_id, client_name, device_id)
-                VALUES (
-                    $user_id, $item_id, $started_utc, $stopped_utc,
-                    $start_position_ticks, $end_position_ticks, $max_position_ticks,
-                    $active_listen_ticks, $seek_forward_count, $seek_backward_count,
-                    $pause_count, $is_early_skip, $duration_ticks, $played_to_completion,
-                    $counted_as_play, $play_session_id, $client_name, $device_id);
-                """;
-            command.Parameters.AddWithValue("$user_id", FormatGuid(activity.UserId));
-            command.Parameters.AddWithValue("$item_id", FormatGuid(activity.ItemId));
-            command.Parameters.AddWithValue("$started_utc", DbValue(activity.StartedUtc));
-            command.Parameters.AddWithValue("$stopped_utc", FormatDate(activity.StoppedUtc));
-            command.Parameters.AddWithValue("$start_position_ticks", DbValue(activity.StartPositionTicks));
-            command.Parameters.AddWithValue("$end_position_ticks", DbValue(activity.EndPositionTicks));
-            command.Parameters.AddWithValue("$max_position_ticks", DbValue(activity.MaxPositionTicks));
-            command.Parameters.AddWithValue("$active_listen_ticks", DbValue(activity.ActiveListenTicks));
-            command.Parameters.AddWithValue("$seek_forward_count", activity.SeekForwardCount);
-            command.Parameters.AddWithValue("$seek_backward_count", activity.SeekBackwardCount);
-            command.Parameters.AddWithValue("$pause_count", activity.PauseCount);
-            command.Parameters.AddWithValue("$is_early_skip", activity.IsEarlySkip ? 1 : 0);
-            command.Parameters.AddWithValue("$duration_ticks", DbValue(activity.DurationTicks));
-            command.Parameters.AddWithValue("$played_to_completion", activity.PlayedToCompletion ? 1 : 0);
-            command.Parameters.AddWithValue("$counted_as_play", activity.CountedAsPlay ? 1 : 0);
-            command.Parameters.AddWithValue("$play_session_id", DbValue(activity.PlaySessionId));
-            command.Parameters.AddWithValue("$client_name", DbValue(activity.ClientName));
-            command.Parameters.AddWithValue("$device_id", DbValue(activity.DeviceId));
-            command.ExecuteNonQuery();
+            using var transaction = connection.BeginTransaction();
+            WritePlayback(connection, transaction, activity);
+            transaction.Commit();
         }
     }
 
@@ -411,6 +486,179 @@ public sealed class ListeningActivityStore
             SchemaVersion = _database.SchemaVersion,
         };
     }
+
+    private static void AddCheckpointParameters(
+        SqliteCommand command,
+        PlaybackSessionCheckpoint checkpoint)
+    {
+        command.Parameters.AddWithValue("$session_key", checkpoint.SessionKey);
+        command.Parameters.AddWithValue("$user_id", FormatGuid(checkpoint.UserId));
+        command.Parameters.AddWithValue("$item_id", FormatGuid(checkpoint.ItemId));
+        command.Parameters.AddWithValue("$started_utc", DbValue(checkpoint.StartedUtc));
+        command.Parameters.AddWithValue(
+            "$last_observed_utc",
+            FormatDate(checkpoint.LastObservedUtc));
+        command.Parameters.AddWithValue(
+            "$start_position_ticks",
+            DbValue(checkpoint.StartPositionTicks));
+        command.Parameters.AddWithValue(
+            "$end_position_ticks",
+            DbValue(checkpoint.EndPositionTicks));
+        command.Parameters.AddWithValue(
+            "$max_position_ticks",
+            DbValue(checkpoint.MaxPositionTicks));
+        command.Parameters.AddWithValue(
+            "$active_listen_ticks",
+            DbValue(checkpoint.ActiveListenTicks));
+        command.Parameters.AddWithValue(
+            "$seek_forward_count",
+            checkpoint.SeekForwardCount);
+        command.Parameters.AddWithValue(
+            "$seek_backward_count",
+            checkpoint.SeekBackwardCount);
+        command.Parameters.AddWithValue("$pause_count", checkpoint.PauseCount);
+        command.Parameters.AddWithValue("$is_paused", checkpoint.IsPaused ? 1 : 0);
+        command.Parameters.AddWithValue("$duration_ticks", DbValue(checkpoint.DurationTicks));
+        command.Parameters.AddWithValue("$play_session_id", DbValue(checkpoint.PlaySessionId));
+        command.Parameters.AddWithValue("$client_name", DbValue(checkpoint.ClientName));
+        command.Parameters.AddWithValue("$device_id", DbValue(checkpoint.DeviceId));
+    }
+
+    private static List<PlaybackSessionCheckpoint> ReadPlaybackSessions(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        DateTimeOffset observedBeforeUtc)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            SELECT
+                session_key, user_id, item_id, started_utc,
+                last_observed_utc, start_position_ticks, end_position_ticks,
+                max_position_ticks, active_listen_ticks, seek_forward_count,
+                seek_backward_count, pause_count, is_paused, duration_ticks,
+                play_session_id, client_name, device_id
+            FROM playback_sessions
+            WHERE last_observed_utc < $observed_before_utc
+            ORDER BY last_observed_utc, session_key, user_id;
+            """;
+        command.Parameters.AddWithValue(
+            "$observed_before_utc",
+            FormatDate(observedBeforeUtc));
+        using var reader = command.ExecuteReader();
+        var checkpoints = new List<PlaybackSessionCheckpoint>();
+        while (reader.Read())
+        {
+            if (!Guid.TryParseExact(reader.GetString(1), "N", out var userId)
+                || !Guid.TryParseExact(reader.GetString(2), "N", out var itemId))
+            {
+                continue;
+            }
+
+            checkpoints.Add(new PlaybackSessionCheckpoint(
+                reader.GetString(0),
+                userId,
+                itemId,
+                ReadDate(reader, 3),
+                ReadDate(reader, 4) ?? DateTimeOffset.MinValue,
+                ReadLong(reader, 5),
+                ReadLong(reader, 6),
+                ReadLong(reader, 7),
+                ReadLong(reader, 8),
+                reader.GetInt32(9),
+                reader.GetInt32(10),
+                reader.GetInt32(11),
+                reader.GetInt32(12) != 0,
+                ReadLong(reader, 13),
+                ReadString(reader, 14),
+                ReadString(reader, 15),
+                ReadString(reader, 16)));
+        }
+
+        return checkpoints;
+    }
+
+    private static void WritePlayback(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        ListeningActivityEvent activity)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            INSERT INTO playback_events (
+                user_id, item_id, started_utc, stopped_utc,
+                start_position_ticks, end_position_ticks, max_position_ticks,
+                active_listen_ticks, seek_forward_count, seek_backward_count,
+                pause_count, is_early_skip, duration_ticks, played_to_completion,
+                counted_as_play, play_session_id, client_name, device_id)
+            VALUES (
+                $user_id, $item_id, $started_utc, $stopped_utc,
+                $start_position_ticks, $end_position_ticks, $max_position_ticks,
+                $active_listen_ticks, $seek_forward_count, $seek_backward_count,
+                $pause_count, $is_early_skip, $duration_ticks, $played_to_completion,
+                $counted_as_play, $play_session_id, $client_name, $device_id);
+            """;
+        command.Parameters.AddWithValue("$user_id", FormatGuid(activity.UserId));
+        command.Parameters.AddWithValue("$item_id", FormatGuid(activity.ItemId));
+        command.Parameters.AddWithValue("$started_utc", DbValue(activity.StartedUtc));
+        command.Parameters.AddWithValue("$stopped_utc", FormatDate(activity.StoppedUtc));
+        command.Parameters.AddWithValue(
+            "$start_position_ticks",
+            DbValue(activity.StartPositionTicks));
+        command.Parameters.AddWithValue("$end_position_ticks", DbValue(activity.EndPositionTicks));
+        command.Parameters.AddWithValue("$max_position_ticks", DbValue(activity.MaxPositionTicks));
+        command.Parameters.AddWithValue("$active_listen_ticks", DbValue(activity.ActiveListenTicks));
+        command.Parameters.AddWithValue("$seek_forward_count", activity.SeekForwardCount);
+        command.Parameters.AddWithValue("$seek_backward_count", activity.SeekBackwardCount);
+        command.Parameters.AddWithValue("$pause_count", activity.PauseCount);
+        command.Parameters.AddWithValue("$is_early_skip", activity.IsEarlySkip ? 1 : 0);
+        command.Parameters.AddWithValue("$duration_ticks", DbValue(activity.DurationTicks));
+        command.Parameters.AddWithValue(
+            "$played_to_completion",
+            activity.PlayedToCompletion ? 1 : 0);
+        command.Parameters.AddWithValue("$counted_as_play", activity.CountedAsPlay ? 1 : 0);
+        command.Parameters.AddWithValue("$play_session_id", DbValue(activity.PlaySessionId));
+        command.Parameters.AddWithValue("$client_name", DbValue(activity.ClientName));
+        command.Parameters.AddWithValue("$device_id", DbValue(activity.DeviceId));
+        command.ExecuteNonQuery();
+    }
+
+    private static void DeletePlaybackSession(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        string sessionKey,
+        Guid? userId = null)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        if (userId is null)
+        {
+            command.CommandText =
+                "DELETE FROM playback_sessions WHERE session_key = $session_key;";
+        }
+        else
+        {
+            command.CommandText = """
+                DELETE FROM playback_sessions
+                WHERE session_key = $session_key AND user_id = $user_id;
+                """;
+        }
+
+        command.Parameters.AddWithValue("$session_key", sessionKey);
+        if (userId is not null)
+        {
+            command.Parameters.AddWithValue("$user_id", FormatGuid(userId.Value));
+        }
+
+        command.ExecuteNonQuery();
+    }
+
+    private static long? ReadLong(SqliteDataReader reader, int ordinal)
+        => reader.IsDBNull(ordinal) ? null : reader.GetInt64(ordinal);
+
+    private static string? ReadString(SqliteDataReader reader, int ordinal)
+        => reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal);
 
     private static string? ReadMetadata(
         SqliteConnection connection,

--- a/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/ListeningActivityTracker.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/ListeningActivityTracker.cs
@@ -15,9 +15,9 @@ using Microsoft.Extensions.Logging;
 namespace Jellyfin.Plugin.Harmonie.Services.ListeningActivity;
 
 /// <summary>
-/// Captures Jellyfin music playback stops and persists them without changing
-/// any recommendation behavior. Existing aggregate activity is imported once
-/// in the background when the database is introduced.
+/// Checkpoints Jellyfin music playback progress and persists completed or
+/// abandoned sessions. Existing aggregate activity is imported once in the
+/// background when the database is introduced.
 /// </summary>
 internal sealed class ListeningActivityTracker : IHostedService, IDisposable
 {
@@ -29,8 +29,8 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
     private readonly ListeningActivityStore _store;
     private readonly IListeningActivityBootstrapSource _bootstrapSource;
     private readonly ILogger<ListeningActivityTracker> _logger;
-    private readonly Channel<ListeningActivityEvent> _writes =
-        Channel.CreateUnbounded<ListeningActivityEvent>(new UnboundedChannelOptions
+    private readonly Channel<ListeningActivityWrite> _writes =
+        Channel.CreateUnbounded<ListeningActivityWrite>(new UnboundedChannelOptions
         {
             SingleReader = true,
             SingleWriter = false,
@@ -43,6 +43,7 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
 
     private Task? _writerTask;
     private Task? _bootstrapTask;
+    private Task? _recoveryTask;
     private long _lastSessionSweepUtcTicks;
     private bool _started;
     private bool _stopped;
@@ -78,6 +79,13 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         try
         {
             _database.Initialize();
+            var recovered = _store.RecoverAbandonedPlaybackSessions(DateTimeOffset.MaxValue);
+            if (recovered > 0)
+            {
+                _logger.LogInformation(
+                    "Recovered {Count} unfinished playback session(s) from the previous run.",
+                    recovered);
+            }
         }
         catch (Exception ex)
         {
@@ -90,6 +98,7 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         _sessionManager.PlaybackStopped += OnPlaybackStopped;
         _writerTask = Task.Run(ProcessWritesAsync, CancellationToken.None);
         _bootstrapTask = Task.Run(BootstrapAsync, CancellationToken.None);
+        _recoveryTask = Task.Run(RecoverStaleSessionsAsync, CancellationToken.None);
         _started = true;
 
         _logger.LogInformation(
@@ -109,8 +118,9 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         _sessionManager.PlaybackProgress -= OnPlaybackProgress;
         _sessionManager.PlaybackStopped -= OnPlaybackStopped;
         await _shutdown.CancelAsync().ConfigureAwait(false);
-        _writes.Writer.TryComplete();
 
+        await AwaitWorkerAsync(_recoveryTask, cancellationToken).ConfigureAwait(false);
+        _writes.Writer.TryComplete();
         await AwaitWorkerAsync(_bootstrapTask, cancellationToken).ConfigureAwait(false);
         await AwaitWorkerAsync(_writerTask, cancellationToken).ConfigureAwait(false);
         _sessions.Clear();
@@ -141,10 +151,12 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         {
             var now = DateTimeOffset.UtcNow;
             SweepStaleSessions(now);
-            _sessions[key] = PlaybackSessionAccumulator.FromStart(
+            var session = PlaybackSessionAccumulator.FromStart(
                 now,
                 eventArgs.PlaybackPositionTicks,
                 eventArgs.IsPaused);
+            _sessions[key] = session;
+            QueueCheckpoint(eventArgs, key, session);
         }
     }
 
@@ -160,19 +172,26 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         {
             var now = DateTimeOffset.UtcNow;
             SweepStaleSessions(now);
-            if (_sessions.TryGetValue(key, out var session))
+            PlaybackSessionAccumulator session;
+            if (_sessions.TryGetValue(key, out var existing))
             {
+                session = existing;
                 session.Observe(now, eventArgs.PlaybackPositionTicks, eventArgs.IsPaused);
             }
             else
             {
-                _sessions.TryAdd(
-                    key,
-                    PlaybackSessionAccumulator.FromProgress(
-                        now,
-                        eventArgs.PlaybackPositionTicks,
-                        eventArgs.IsPaused));
+                session = PlaybackSessionAccumulator.FromProgress(
+                    now,
+                    eventArgs.PlaybackPositionTicks,
+                    eventArgs.IsPaused);
+                if (!_sessions.TryAdd(key, session))
+                {
+                    session = _sessions[key];
+                    session.Observe(now, eventArgs.PlaybackPositionTicks, eventArgs.IsPaused);
+                }
             }
+
+            QueueCheckpoint(eventArgs, key, session);
         }
     }
 
@@ -200,15 +219,56 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
             eventArgs.PlaybackPositionTicks,
             audio.RunTimeTicks);
 
-        foreach (var activity in CreateActivities(eventArgs, summary, now))
+        var activities = CreateActivities(eventArgs, summary, now);
+        if (!_writes.Writer.TryWrite(new CompletePlaybackWrite(key, activities)))
         {
-            if (!_writes.Writer.TryWrite(activity))
-            {
-                _logger.LogWarning(
-                    "Could not queue listening activity for item {ItemId}; the tracker is stopping.",
-                    audio.Id);
-            }
+            _logger.LogWarning(
+                "Could not queue listening activity for item {ItemId}; the tracker is stopping.",
+                audio.Id);
         }
+    }
+
+    private void QueueCheckpoint(
+        PlaybackProgressEventArgs eventArgs,
+        string sessionKey,
+        PlaybackSessionAccumulator session)
+    {
+        var checkpoints = CreateCheckpoints(eventArgs, sessionKey, session);
+        if (checkpoints.Count > 0
+            && !_writes.Writer.TryWrite(new CheckpointPlaybackWrite(checkpoints)))
+        {
+            _logger.LogWarning(
+                "Could not checkpoint playback session {SessionKey}; the tracker is stopping.",
+                sessionKey);
+        }
+    }
+
+    internal static IReadOnlyList<PlaybackSessionCheckpoint> CreateCheckpoints(
+        PlaybackProgressEventArgs eventArgs,
+        string sessionKey,
+        PlaybackSessionAccumulator session)
+    {
+        ArgumentNullException.ThrowIfNull(eventArgs);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionKey);
+        ArgumentNullException.ThrowIfNull(session);
+        if (eventArgs.Item is not Audio audio)
+        {
+            return Array.Empty<PlaybackSessionCheckpoint>();
+        }
+
+        return eventArgs.Users
+            .Select(user => user.Id)
+            .Where(userId => userId != Guid.Empty)
+            .Distinct()
+            .Select(userId => session.CreateCheckpoint(
+                sessionKey,
+                userId,
+                audio.Id,
+                audio.RunTimeTicks,
+                eventArgs.PlaySessionId,
+                eventArgs.ClientName,
+                eventArgs.DeviceId))
+            .ToList();
     }
 
     internal static IReadOnlyList<ListeningActivityEvent> CreateActivities(
@@ -251,20 +311,57 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
 
     private async Task ProcessWritesAsync()
     {
-        await foreach (var activity in _writes.Reader.ReadAllAsync().ConfigureAwait(false))
+        await foreach (var write in _writes.Reader.ReadAllAsync().ConfigureAwait(false))
         {
             try
             {
-                _store.RecordPlayback(activity);
+                switch (write)
+                {
+                    case CheckpointPlaybackWrite checkpoint:
+                        _store.UpsertPlaybackSessions(checkpoint.Checkpoints);
+                        break;
+                    case CompletePlaybackWrite complete:
+                        _store.CompletePlaybackSession(
+                            complete.SessionKey,
+                            complete.Activities);
+                        break;
+                    case RecoverPlaybackWrite recover:
+                        var recovered = _store.RecoverAbandonedPlaybackSessions(
+                            recover.ObservedBeforeUtc);
+                        if (recovered > 0)
+                        {
+                            _logger.LogDebug(
+                                "Recovered {Count} stale playback session(s).",
+                                recovered);
+                        }
+
+                        break;
+                }
             }
             catch (Exception ex)
             {
                 _logger.LogError(
                     ex,
-                    "Could not store listening activity for item {ItemId} and user {UserId}.",
-                    activity.ItemId,
-                    activity.UserId);
+                    "Could not apply a listening activity database write.");
             }
+        }
+    }
+
+    private async Task RecoverStaleSessionsAsync()
+    {
+        using var timer = new PeriodicTimer(SessionSweepInterval);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(_shutdown.Token).ConfigureAwait(false))
+            {
+                var cutoff = DateTimeOffset.UtcNow - SessionRetention;
+                EvictStaleSessions(_sessions, cutoff);
+                _writes.Writer.TryWrite(new RecoverPlaybackWrite(cutoff));
+            }
+        }
+        catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
+        {
+            // Normal hosted-service shutdown.
         }
     }
 
@@ -331,6 +428,8 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         }
 
         var removed = EvictStaleSessions(_sessions, observedAt - SessionRetention);
+        _writes.Writer.TryWrite(
+            new RecoverPlaybackWrite(observedAt - SessionRetention));
         if (removed > 0)
         {
             _logger.LogDebug("Removed {Count} stale playback session(s).", removed);
@@ -361,4 +460,16 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
 
         await task.WaitAsync(cancellationToken).ConfigureAwait(false);
     }
+
+    private abstract record ListeningActivityWrite;
+
+    private sealed record CheckpointPlaybackWrite(
+        IReadOnlyList<PlaybackSessionCheckpoint> Checkpoints) : ListeningActivityWrite;
+
+    private sealed record CompletePlaybackWrite(
+        string SessionKey,
+        IReadOnlyList<ListeningActivityEvent> Activities) : ListeningActivityWrite;
+
+    private sealed record RecoverPlaybackWrite(
+        DateTimeOffset ObservedBeforeUtc) : ListeningActivityWrite;
 }

--- a/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/ListeningActivityTracker.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/ListeningActivityTracker.cs
@@ -29,6 +29,12 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
     private static readonly TimeSpan CheckpointRetention = TimeSpan.FromHours(24);
     private static readonly TimeSpan SessionSweepInterval = TimeSpan.FromHours(1);
 
+    // A stop tombstones its session key briefly so straggler progress events
+    // (the server's automated ticks race real stops) can neither checkpoint
+    // nor rehydrate a session that just completed. A new play for the same
+    // key clears the tombstone through its start event.
+    private static readonly TimeSpan CompletedKeyRetention = TimeSpan.FromMinutes(5);
+
     private readonly ISessionManager _sessionManager;
     private readonly HarmonieDatabase _database;
     private readonly ListeningActivityStore _store;
@@ -42,6 +48,9 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         });
 
     private readonly ConcurrentDictionary<string, PlaybackSessionAccumulator> _sessions =
+        new(StringComparer.Ordinal);
+
+    private readonly ConcurrentDictionary<string, DateTimeOffset> _completedKeys =
         new(StringComparer.Ordinal);
 
     private readonly CancellationTokenSource _shutdown = new();
@@ -140,6 +149,7 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         await AwaitWorkerAsync(_bootstrapTask, cancellationToken).ConfigureAwait(false);
         await AwaitWorkerAsync(_writerTask, cancellationToken).ConfigureAwait(false);
         _sessions.Clear();
+        _completedKeys.Clear();
         _started = false;
         _stopped = true;
     }
@@ -167,6 +177,7 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         {
             var now = DateTimeOffset.UtcNow;
             SweepStaleSessions(now);
+            _completedKeys.TryRemove(key, out _);
             var session = PlaybackSessionAccumulator.FromStart(
                 now,
                 eventArgs.PlaybackPositionTicks,
@@ -184,7 +195,7 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         }
 
         var key = ActivityKey(eventArgs);
-        if (key is not null)
+        if (key is not null && !_completedKeys.ContainsKey(key))
         {
             var now = DateTimeOffset.UtcNow;
             SweepStaleSessions(now);
@@ -233,6 +244,11 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
 
         if (!_sessions.TryRemove(key, out var session))
         {
+            if (_completedKeys.ContainsKey(key))
+            {
+                return;
+            }
+
             // The in-memory session may have been evicted (long pause, plugin
             // restart) while its durable checkpoint survived. Resume from the
             // checkpoint so the whole listen still lands as one event.
@@ -247,13 +263,15 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
             }
         }
 
+        _completedKeys[key] = now;
+
         var summary = session.Finish(
             now,
             eventArgs.PlaybackPositionTicks,
             audio.RunTimeTicks);
 
         var activities = CreateActivities(eventArgs, summary, now);
-        if (!_writes.Writer.TryWrite(new CompletePlaybackWrite(key, activities)))
+        if (!_writes.Writer.TryWrite(new CompletePlaybackWrite(key, session.Generation, activities)))
         {
             _logger.LogWarning(
                 "Could not queue listening activity for item {ItemId}; the tracker is stopping.",
@@ -287,14 +305,17 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         string sessionKey,
         PlaybackSessionAccumulator session)
     {
-        if (!session.ShouldCheckpoint(DateTimeOffset.UtcNow))
+        if (!session.ShouldCheckpoint(
+                DateTimeOffset.UtcNow,
+                (eventArgs.Item as Audio)?.RunTimeTicks))
         {
             return;
         }
 
         var checkpoints = CreateCheckpoints(eventArgs, sessionKey, session);
         if (checkpoints.Count > 0
-            && !_writes.Writer.TryWrite(new CheckpointPlaybackWrite(checkpoints)))
+            && !_writes.Writer.TryWrite(
+                new CheckpointPlaybackWrite(session.Generation, checkpoints)))
         {
             _logger.LogWarning(
                 "Could not checkpoint playback session {SessionKey}; the tracker is stopping.",
@@ -370,6 +391,10 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
 
     private async Task ProcessWritesAsync()
     {
+        // Generations completed recently; a checkpoint that lost the race
+        // against its session's completion must not resurrect the session.
+        var completedGenerations = new HashSet<long>();
+        var completedOrder = new Queue<long>();
         await foreach (var write in _writes.Reader.ReadAllAsync().ConfigureAwait(false))
         {
             try
@@ -377,12 +402,23 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
                 switch (write)
                 {
                     case CheckpointPlaybackWrite checkpoint:
-                        _store.UpsertPlaybackSessions(checkpoint.Checkpoints);
+                        if (!completedGenerations.Contains(checkpoint.Generation))
+                        {
+                            _store.UpsertPlaybackSessions(checkpoint.Checkpoints);
+                        }
+
                         break;
                     case CompletePlaybackWrite complete:
                         _store.CompletePlaybackSession(
                             complete.SessionKey,
                             complete.Activities);
+                        completedGenerations.Add(complete.Generation);
+                        completedOrder.Enqueue(complete.Generation);
+                        while (completedOrder.Count > 4096)
+                        {
+                            completedGenerations.Remove(completedOrder.Dequeue());
+                        }
+
                         break;
                     case RecoverPlaybackWrite recover:
                         var recovered = _store.RecoverAbandonedPlaybackSessions(
@@ -488,6 +524,15 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         }
 
         var removed = EvictStaleSessions(_sessions, observedAt - SessionRetention);
+        foreach (var entry in _completedKeys)
+        {
+            if (entry.Value < observedAt - CompletedKeyRetention)
+            {
+                ((ICollection<KeyValuePair<string, DateTimeOffset>>)_completedKeys)
+                    .Remove(entry);
+            }
+        }
+
         if (removed > 0)
         {
             _logger.LogDebug("Removed {Count} stale playback session(s).", removed);
@@ -522,10 +567,12 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
     private abstract record ListeningActivityWrite;
 
     private sealed record CheckpointPlaybackWrite(
+        long Generation,
         IReadOnlyList<PlaybackSessionCheckpoint> Checkpoints) : ListeningActivityWrite;
 
     private sealed record CompletePlaybackWrite(
         string SessionKey,
+        long Generation,
         IReadOnlyList<ListeningActivityEvent> Activities) : ListeningActivityWrite;
 
     private sealed record RecoverPlaybackWrite(

--- a/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/ListeningActivityTracker.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/ListeningActivityTracker.cs
@@ -21,7 +21,12 @@ namespace Jellyfin.Plugin.Harmonie.Services.ListeningActivity;
 /// </summary>
 internal sealed class ListeningActivityTracker : IHostedService, IDisposable
 {
+    // In-memory accumulators are dropped after six quiet hours; their durable
+    // checkpoints live on for a day so a resumed session (an overnight pause,
+    // a sleeping device) continues as one listen instead of splitting in two.
+    // Only after a quiet day is a checkpoint finalized as a playback event.
     private static readonly TimeSpan SessionRetention = TimeSpan.FromHours(6);
+    private static readonly TimeSpan CheckpointRetention = TimeSpan.FromHours(24);
     private static readonly TimeSpan SessionSweepInterval = TimeSpan.FromHours(1);
 
     private readonly ISessionManager _sessionManager;
@@ -79,7 +84,19 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         try
         {
             _database.Initialize();
-            var recovered = _store.RecoverAbandonedPlaybackSessions(DateTimeOffset.MaxValue);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Could not initialize the Harmonie listening activity database; tracking is disabled.");
+            return Task.CompletedTask;
+        }
+
+        // A recovery failure must not disable tracking; the periodic sweep
+        // retries every hour.
+        try
+        {
+            var recovered = _store.RecoverAbandonedPlaybackSessions(
+                DateTimeOffset.UtcNow - CheckpointRetention);
             if (recovered > 0)
             {
                 _logger.LogInformation(
@@ -89,8 +106,7 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Could not initialize the Harmonie listening activity database; tracking is disabled.");
-            return Task.CompletedTask;
+            _logger.LogError(ex, "Could not recover unfinished playback sessions; continuing.");
         }
 
         _sessionManager.PlaybackStart += OnPlaybackStart;
@@ -180,11 +196,16 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
             }
             else
             {
-                session = PlaybackSessionAccumulator.FromProgress(
-                    now,
-                    eventArgs.PlaybackPositionTicks,
-                    eventArgs.IsPaused);
-                if (!_sessions.TryAdd(key, session))
+                session = ResumeFromCheckpoint(key, now)
+                    ?? PlaybackSessionAccumulator.FromProgress(
+                        now,
+                        eventArgs.PlaybackPositionTicks,
+                        eventArgs.IsPaused);
+                if (_sessions.TryAdd(key, session))
+                {
+                    session.Observe(now, eventArgs.PlaybackPositionTicks, eventArgs.IsPaused);
+                }
+                else
                 {
                     session = _sessions[key];
                     session.Observe(now, eventArgs.PlaybackPositionTicks, eventArgs.IsPaused);
@@ -205,13 +226,25 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         var now = DateTimeOffset.UtcNow;
         SweepStaleSessions(now);
         var key = ActivityKey(eventArgs);
-        if (key is null || !_sessions.TryRemove(key, out var session))
+        if (key is null)
         {
-            _logger.LogDebug(
-                "Ignoring unmatched playback stop for item {ItemId} and play session {PlaySessionId}.",
-                audio.Id,
-                eventArgs.PlaySessionId);
             return;
+        }
+
+        if (!_sessions.TryRemove(key, out var session))
+        {
+            // The in-memory session may have been evicted (long pause, plugin
+            // restart) while its durable checkpoint survived. Resume from the
+            // checkpoint so the whole listen still lands as one event.
+            session = ResumeFromCheckpoint(key, now);
+            if (session is null)
+            {
+                _logger.LogDebug(
+                    "Ignoring unmatched playback stop for item {ItemId} and play session {PlaySessionId}.",
+                    audio.Id,
+                    eventArgs.PlaySessionId);
+                return;
+            }
         }
 
         var summary = session.Finish(
@@ -228,11 +261,37 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         }
     }
 
+    private PlaybackSessionAccumulator? ResumeFromCheckpoint(
+        string sessionKey,
+        DateTimeOffset resumedAt)
+    {
+        try
+        {
+            var checkpoint = _store.TryGetPlaybackSession(sessionKey);
+            return checkpoint is null
+                ? null
+                : PlaybackSessionAccumulator.FromCheckpoint(checkpoint, resumedAt);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Could not resume playback session {SessionKey} from its checkpoint.",
+                sessionKey);
+            return null;
+        }
+    }
+
     private void QueueCheckpoint(
         PlaybackProgressEventArgs eventArgs,
         string sessionKey,
         PlaybackSessionAccumulator session)
     {
+        if (!session.ShouldCheckpoint(DateTimeOffset.UtcNow))
+        {
+            return;
+        }
+
         var checkpoints = CreateCheckpoints(eventArgs, sessionKey, session);
         if (checkpoints.Count > 0
             && !_writes.Writer.TryWrite(new CheckpointPlaybackWrite(checkpoints)))
@@ -354,9 +413,10 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         {
             while (await timer.WaitForNextTickAsync(_shutdown.Token).ConfigureAwait(false))
             {
-                var cutoff = DateTimeOffset.UtcNow - SessionRetention;
-                EvictStaleSessions(_sessions, cutoff);
-                _writes.Writer.TryWrite(new RecoverPlaybackWrite(cutoff));
+                var now = DateTimeOffset.UtcNow;
+                EvictStaleSessions(_sessions, now - SessionRetention);
+                _writes.Writer.TryWrite(
+                    new RecoverPlaybackWrite(now - CheckpointRetention));
             }
         }
         catch (OperationCanceledException) when (_shutdown.IsCancellationRequested)
@@ -428,8 +488,6 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         }
 
         var removed = EvictStaleSessions(_sessions, observedAt - SessionRetention);
-        _writes.Writer.TryWrite(
-            new RecoverPlaybackWrite(observedAt - SessionRetention));
         if (removed > 0)
         {
             _logger.LogDebug("Removed {Count} stale playback session(s).", removed);

--- a/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/PlaybackSessionAccumulator.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/PlaybackSessionAccumulator.cs
@@ -15,8 +15,8 @@ internal sealed record PlaybackSessionSummary(
     bool IsEarlySkip);
 
 /// <summary>
-/// Reduces frequent Jellyfin progress events to one playback summary without
-/// writing each progress sample to the database.
+/// Reduces Jellyfin progress events to current playback metrics that can be
+/// checkpointed and finalized as one playback event.
 /// </summary>
 internal sealed class PlaybackSessionAccumulator
 {
@@ -92,23 +92,119 @@ internal sealed class PlaybackSessionAccumulator
         lock (_sync)
         {
             ObserveCore(stoppedAt, endPositionTicks, _isPaused);
-            long? activeListenTicks = _hasPlaybackStart ? _activeListenTicks : null;
-            var playedToCompletion = IsPlayedToCompletion(
-                endPositionTicks,
-                activeListenTicks,
-                durationTicks);
-            return new PlaybackSessionSummary(
+            return CreateSummary(durationTicks);
+        }
+    }
+
+    internal PlaybackSessionCheckpoint CreateCheckpoint(
+        string sessionKey,
+        Guid userId,
+        Guid itemId,
+        long? durationTicks,
+        string? playSessionId,
+        string? clientName,
+        string? deviceId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sessionKey);
+        lock (_sync)
+        {
+            return new PlaybackSessionCheckpoint(
+                sessionKey,
+                userId,
+                itemId,
                 _startedUtc,
+                _lastObservedAt,
                 _startPositionTicks,
-                endPositionTicks,
+                _lastPositionTicks,
                 _maxPositionTicks,
-                activeListenTicks,
+                _hasPlaybackStart ? _activeListenTicks : null,
                 _seekForwardCount,
                 _seekBackwardCount,
                 _pauseCount,
-                playedToCompletion,
-                IsEarlySkip(activeListenTicks, durationTicks, playedToCompletion));
+                _isPaused,
+                durationTicks,
+                playSessionId,
+                clientName,
+                deviceId);
         }
+    }
+
+    internal static ListeningActivityEvent Recover(PlaybackSessionCheckpoint checkpoint)
+    {
+        ArgumentNullException.ThrowIfNull(checkpoint);
+        var playedToCompletion = IsPlayedToCompletion(
+            checkpoint.EndPositionTicks,
+            checkpoint.ActiveListenTicks,
+            checkpoint.DurationTicks);
+        return new ListeningActivityEvent(
+            checkpoint.UserId,
+            checkpoint.ItemId,
+            checkpoint.StartedUtc,
+            checkpoint.LastObservedUtc,
+            checkpoint.StartPositionTicks,
+            checkpoint.EndPositionTicks,
+            checkpoint.MaxPositionTicks,
+            checkpoint.ActiveListenTicks,
+            checkpoint.SeekForwardCount,
+            checkpoint.SeekBackwardCount,
+            checkpoint.PauseCount,
+            IsEarlySkip(
+                checkpoint.ActiveListenTicks is not null,
+                checkpoint.ActiveListenTicks,
+                checkpoint.DurationTicks,
+                playedToCompletion),
+            checkpoint.DurationTicks,
+            playedToCompletion,
+            IsCountedAsPlay(
+                checkpoint.EndPositionTicks,
+                checkpoint.ActiveListenTicks,
+                checkpoint.DurationTicks),
+            checkpoint.PlaySessionId,
+            checkpoint.ClientName,
+            checkpoint.DeviceId);
+    }
+
+    internal static bool IsCountedAsPlay(
+        long? endPositionTicks,
+        long? activeListenTicks,
+        long? durationTicks)
+    {
+        if (endPositionTicks is null
+            || activeListenTicks is null
+            || durationTicks is null
+            || durationTicks <= 0
+            || activeListenTicks < durationTicks / 2)
+        {
+            return false;
+        }
+
+        var remainingTicks = Math.Max(0, durationTicks.Value - endPositionTicks.Value);
+        return remainingTicks <= TimeSpan.FromSeconds(10).Ticks
+            || activeListenTicks.Value >= durationTicks.Value * 0.9;
+    }
+
+    private PlaybackSessionSummary CreateSummary(long? durationTicks)
+    {
+        long? activeListenTicks = _hasPlaybackStart ? _activeListenTicks : null;
+        var playedToCompletion = IsPlayedToCompletion(
+            _lastPositionTicks,
+            activeListenTicks,
+            durationTicks);
+        return new PlaybackSessionSummary(
+            _startedUtc,
+            _startPositionTicks,
+            _lastPositionTicks,
+            _maxPositionTicks,
+            activeListenTicks,
+            _seekForwardCount,
+            _seekBackwardCount,
+            _pauseCount,
+            playedToCompletion,
+            IsEarlySkip(
+                _hasPlaybackStart,
+                activeListenTicks,
+                durationTicks,
+                playedToCompletion));
     }
 
     private static bool IsPlayedToCompletion(
@@ -130,7 +226,7 @@ internal sealed class PlaybackSessionAccumulator
         // small margin when reporting the final position.
         var toleranceTicks = Math.Min(
             CompletionToleranceLimitTicks,
-            durationTicks.Value / 20);
+            durationTicks.Value / 5);
         return endPositionTicks.Value >= durationTicks.Value - toleranceTicks;
     }
 
@@ -182,12 +278,13 @@ internal sealed class PlaybackSessionAccumulator
         _isPaused = isPaused;
     }
 
-    private bool IsEarlySkip(
+    private static bool IsEarlySkip(
+        bool hasPlaybackStart,
         long? activeListenTicks,
         long? durationTicks,
         bool playedToCompletion)
     {
-        if (!_hasPlaybackStart
+        if (!hasPlaybackStart
             || playedToCompletion
             || activeListenTicks is null
             || durationTicks is null

--- a/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/PlaybackSessionAccumulator.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/PlaybackSessionAccumulator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace Jellyfin.Plugin.Harmonie.Services.ListeningActivity;
 
@@ -31,6 +32,14 @@ internal sealed class PlaybackSessionAccumulator
     private static readonly long EarlySkipLimitTicks = TimeSpan.FromSeconds(30).Ticks;
     private static readonly long CompletionToleranceLimitTicks = TimeSpan.FromSeconds(10).Ticks;
     private static readonly TimeSpan CheckpointWriteInterval = TimeSpan.FromSeconds(30);
+
+    // Near the end of a track the durable state must not lag: recovery
+    // counts a play only when the persisted position is close to the end,
+    // so a 30-second-stale checkpoint would drop a near-complete listen.
+    private static readonly long EndZoneTicks = TimeSpan.FromSeconds(45).Ticks;
+    private static readonly TimeSpan EndZoneCheckpointInterval = TimeSpan.FromSeconds(5);
+
+    private static long _nextGeneration;
 
     private readonly object _sync = new();
     private readonly DateTimeOffset? _startedUtc;
@@ -96,6 +105,13 @@ internal sealed class PlaybackSessionAccumulator
         }
     }
 
+    /// <summary>
+    /// Gets a value identifying this accumulator instance across the write
+    /// queue, so a checkpoint that was queued after its session completed
+    /// can be rejected instead of resurrecting the session.
+    /// </summary>
+    internal long Generation { get; } = Interlocked.Increment(ref _nextGeneration);
+
     internal static PlaybackSessionAccumulator FromStart(
         DateTimeOffset startedAt,
         long? positionTicks,
@@ -124,14 +140,23 @@ internal sealed class PlaybackSessionAccumulator
         }
     }
 
-    internal bool ShouldCheckpoint(DateTimeOffset now)
+    internal bool ShouldCheckpoint(DateTimeOffset now, long? durationTicks)
     {
         lock (_sync)
         {
             // Progress events arrive every few seconds; a checkpoint only
             // needs the latest state within the write interval, except when
-            // a pause or seek transition would otherwise be lost.
-            if (now - _lastCheckpointAt < CheckpointWriteInterval
+            // a pause or seek transition would otherwise be lost, or when
+            // the track nears its end and recovery accuracy is at stake.
+            var interval = CheckpointWriteInterval;
+            if (durationTicks is > 0
+                && _lastPositionTicks is not null
+                && durationTicks.Value - _lastPositionTicks.Value <= EndZoneTicks)
+            {
+                interval = EndZoneCheckpointInterval;
+            }
+
+            if (now - _lastCheckpointAt < interval
                 && _checkpointedPauseCount == _pauseCount
                 && _checkpointedSeekForwardCount == _seekForwardCount
                 && _checkpointedSeekBackwardCount == _seekBackwardCount

--- a/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/PlaybackSessionAccumulator.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/PlaybackSessionAccumulator.cs
@@ -20,9 +20,17 @@ internal sealed record PlaybackSessionSummary(
 /// </summary>
 internal sealed class PlaybackSessionAccumulator
 {
+    // A live stop reports the real end position, so completion keeps a tight
+    // margin. A recovered checkpoint ends at the last progress report, which
+    // lags the true end by up to one report interval, so recovery gets a
+    // wider margin on short tracks.
+    private const long LiveCompletionToleranceDivisor = 20;
+    private const long RecoveredCompletionToleranceDivisor = 5;
+
     private static readonly long SeekThresholdTicks = TimeSpan.FromSeconds(10).Ticks;
     private static readonly long EarlySkipLimitTicks = TimeSpan.FromSeconds(30).Ticks;
     private static readonly long CompletionToleranceLimitTicks = TimeSpan.FromSeconds(10).Ticks;
+    private static readonly TimeSpan CheckpointWriteInterval = TimeSpan.FromSeconds(30);
 
     private readonly object _sync = new();
     private readonly DateTimeOffset? _startedUtc;
@@ -36,6 +44,11 @@ internal sealed class PlaybackSessionAccumulator
     private int _seekForwardCount;
     private int _seekBackwardCount;
     private int _pauseCount;
+    private DateTimeOffset _lastCheckpointAt = DateTimeOffset.MinValue;
+    private int _checkpointedSeekForwardCount;
+    private int _checkpointedSeekBackwardCount;
+    private int _checkpointedPauseCount;
+    private bool _checkpointedIsPaused;
 
     private PlaybackSessionAccumulator(
         DateTimeOffset? startedUtc,
@@ -51,6 +64,25 @@ internal sealed class PlaybackSessionAccumulator
         _maxPositionTicks = positionTicks;
         _isPaused = isPaused;
         _hasPlaybackStart = hasPlaybackStart;
+    }
+
+    private PlaybackSessionAccumulator(
+        PlaybackSessionCheckpoint checkpoint,
+        DateTimeOffset resumedAt)
+    {
+        _startedUtc = checkpoint.StartedUtc;
+        _hasPlaybackStart = checkpoint.ActiveListenTicks is not null;
+        _startPositionTicks = checkpoint.StartPositionTicks;
+        // Resuming from now means the silent gap between the checkpoint and
+        // this moment is never credited as listening time.
+        _lastObservedAt = resumedAt;
+        _lastPositionTicks = checkpoint.EndPositionTicks;
+        _maxPositionTicks = checkpoint.MaxPositionTicks;
+        _activeListenTicks = checkpoint.ActiveListenTicks ?? 0;
+        _isPaused = checkpoint.IsPaused;
+        _seekForwardCount = checkpoint.SeekForwardCount;
+        _seekBackwardCount = checkpoint.SeekBackwardCount;
+        _pauseCount = checkpoint.PauseCount;
     }
 
     internal DateTimeOffset LastObservedUtc
@@ -76,11 +108,44 @@ internal sealed class PlaybackSessionAccumulator
         bool isPaused)
         => new(null, observedAt, positionTicks, isPaused, hasPlaybackStart: false);
 
+    internal static PlaybackSessionAccumulator FromCheckpoint(
+        PlaybackSessionCheckpoint checkpoint,
+        DateTimeOffset resumedAt)
+    {
+        ArgumentNullException.ThrowIfNull(checkpoint);
+        return new(checkpoint, resumedAt);
+    }
+
     internal void Observe(DateTimeOffset observedAt, long? positionTicks, bool isPaused)
     {
         lock (_sync)
         {
             ObserveCore(observedAt, positionTicks, isPaused);
+        }
+    }
+
+    internal bool ShouldCheckpoint(DateTimeOffset now)
+    {
+        lock (_sync)
+        {
+            // Progress events arrive every few seconds; a checkpoint only
+            // needs the latest state within the write interval, except when
+            // a pause or seek transition would otherwise be lost.
+            if (now - _lastCheckpointAt < CheckpointWriteInterval
+                && _checkpointedPauseCount == _pauseCount
+                && _checkpointedSeekForwardCount == _seekForwardCount
+                && _checkpointedSeekBackwardCount == _seekBackwardCount
+                && _checkpointedIsPaused == _isPaused)
+            {
+                return false;
+            }
+
+            _lastCheckpointAt = now;
+            _checkpointedPauseCount = _pauseCount;
+            _checkpointedSeekForwardCount = _seekForwardCount;
+            _checkpointedSeekBackwardCount = _seekBackwardCount;
+            _checkpointedIsPaused = _isPaused;
+            return true;
         }
     }
 
@@ -135,7 +200,8 @@ internal sealed class PlaybackSessionAccumulator
         var playedToCompletion = IsPlayedToCompletion(
             checkpoint.EndPositionTicks,
             checkpoint.ActiveListenTicks,
-            checkpoint.DurationTicks);
+            checkpoint.DurationTicks,
+            RecoveredCompletionToleranceDivisor);
         return new ListeningActivityEvent(
             checkpoint.UserId,
             checkpoint.ItemId,
@@ -189,7 +255,8 @@ internal sealed class PlaybackSessionAccumulator
         var playedToCompletion = IsPlayedToCompletion(
             _lastPositionTicks,
             activeListenTicks,
-            durationTicks);
+            durationTicks,
+            LiveCompletionToleranceDivisor);
         return new PlaybackSessionSummary(
             _startedUtc,
             _startPositionTicks,
@@ -210,7 +277,8 @@ internal sealed class PlaybackSessionAccumulator
     private static bool IsPlayedToCompletion(
         long? endPositionTicks,
         long? activeListenTicks,
-        long? durationTicks)
+        long? durationTicks,
+        long toleranceDivisor)
     {
         if (endPositionTicks is null
             || activeListenTicks is null
@@ -226,7 +294,7 @@ internal sealed class PlaybackSessionAccumulator
         // small margin when reporting the final position.
         var toleranceTicks = Math.Min(
             CompletionToleranceLimitTicks,
-            durationTicks.Value / 5);
+            durationTicks.Value / toleranceDivisor);
         return endPositionTicks.Value >= durationTicks.Value - toleranceTicks;
     }
 

--- a/Jellyfin.Plugin.Harmonie/Services/Storage/HarmonieDatabaseMigrations.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/Storage/HarmonieDatabaseMigrations.cs
@@ -10,5 +10,6 @@ internal static class HarmonieDatabaseMigrations
         {
             new Migration001ListeningActivity(),
             new Migration002RecommendationMetricsIndex(),
+            new Migration003PlaybackSessionCheckpoints(),
         };
 }

--- a/Jellyfin.Plugin.Harmonie/Services/Storage/Migrations/Migration003PlaybackSessionCheckpoints.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/Storage/Migrations/Migration003PlaybackSessionCheckpoints.cs
@@ -1,0 +1,40 @@
+using Microsoft.Data.Sqlite;
+
+namespace Jellyfin.Plugin.Harmonie.Services.Storage.Migrations;
+
+internal sealed class Migration003PlaybackSessionCheckpoints : IHarmonieDatabaseMigration
+{
+    public int Version => 3;
+
+    public void Apply(SqliteConnection connection, SqliteTransaction transaction)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            CREATE TABLE playback_sessions (
+                session_key TEXT NOT NULL,
+                user_id TEXT NOT NULL,
+                item_id TEXT NOT NULL,
+                started_utc TEXT NULL,
+                last_observed_utc TEXT NOT NULL,
+                start_position_ticks INTEGER NULL,
+                end_position_ticks INTEGER NULL,
+                max_position_ticks INTEGER NULL,
+                active_listen_ticks INTEGER NULL,
+                seek_forward_count INTEGER NOT NULL CHECK (seek_forward_count >= 0),
+                seek_backward_count INTEGER NOT NULL CHECK (seek_backward_count >= 0),
+                pause_count INTEGER NOT NULL CHECK (pause_count >= 0),
+                is_paused INTEGER NOT NULL CHECK (is_paused IN (0, 1)),
+                duration_ticks INTEGER NULL,
+                play_session_id TEXT NULL,
+                client_name TEXT NULL,
+                device_id TEXT NULL,
+                PRIMARY KEY (session_key, user_id)
+            );
+
+            CREATE INDEX ix_playback_sessions_last_observed
+                ON playback_sessions (last_observed_utc);
+            """;
+        command.ExecuteNonQuery();
+    }
+}

--- a/tests/Jellyfin.Plugin.Harmonie.Tests/HarmonieDatabaseTests.cs
+++ b/tests/Jellyfin.Plugin.Harmonie.Tests/HarmonieDatabaseTests.cs
@@ -76,7 +76,7 @@ public sealed class HarmonieDatabaseTests : IDisposable
     }
 
     [Fact]
-    public void Recommendation_index_is_added_when_schema_one_is_upgraded()
+    public void Recommendation_index_and_checkpoint_table_are_added_when_schema_one_is_upgraded()
     {
         var path = Path.Combine(_directory, "jellyfin-harmonie.db");
         new HarmonieDatabase(
@@ -97,8 +97,16 @@ public sealed class HarmonieDatabaseTests : IDisposable
             columns.Add(reader.GetString(2));
         }
 
-        Assert.Equal(2, upgraded.SchemaVersion);
+        Assert.Equal(3, upgraded.SchemaVersion);
         Assert.Equal(new[] { "user_id", "item_id", "stopped_utc" }, columns);
+
+        using var tableCommand = connection.CreateCommand();
+        tableCommand.CommandText = """
+            SELECT COUNT(*)
+            FROM sqlite_master
+            WHERE type = 'table' AND name = 'playback_sessions';
+            """;
+        Assert.Equal(1L, tableCommand.ExecuteScalar());
     }
 
     private sealed class RecordingMigration : IHarmonieDatabaseMigration

--- a/tests/Jellyfin.Plugin.Harmonie.Tests/ListeningActivityStoreTests.cs
+++ b/tests/Jellyfin.Plugin.Harmonie.Tests/ListeningActivityStoreTests.cs
@@ -483,6 +483,50 @@ public sealed class ListeningActivityStoreTests : IDisposable
         Assert.Equal("phone", reader.GetString(6));
     }
 
+    [Fact]
+    public void Resumed_checkpoint_finishes_as_a_single_event()
+    {
+        var store = CreateStore();
+        var userId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        var observedAt = DateTimeOffset.Parse("2026-08-16T12:00:00Z");
+        store.UpsertPlaybackSessions(new[]
+        {
+            Checkpoint(userId, itemId, observedAt),
+        });
+
+        var checkpoint = store.TryGetPlaybackSession("session-1");
+        Assert.NotNull(checkpoint);
+        var resumedAt = observedAt.AddHours(10);
+        var session = PlaybackSessionAccumulator.FromCheckpoint(checkpoint, resumedAt);
+        var summary = session.Finish(
+            resumedAt.AddSeconds(10),
+            TimeSpan.FromMinutes(3).Ticks,
+            TimeSpan.FromMinutes(3).Ticks);
+        store.CompletePlaybackSession(
+            "session-1",
+            new[]
+            {
+                Playback(
+                    userId,
+                    itemId,
+                    resumedAt.AddSeconds(10),
+                    completed: summary.PlayedToCompletion,
+                    earlySkip: summary.IsEarlySkip),
+            });
+
+        using var connection = new HarmonieDatabase(
+            Path.Combine(_directory, "jellyfin-harmonie.db")).OpenConnection();
+        Assert.Equal(0L, Scalar(connection, "SELECT COUNT(*) FROM playback_sessions;"));
+        Assert.Equal(1L, Scalar(connection, "SELECT COUNT(*) FROM playback_events;"));
+    }
+
+    [Fact]
+    public void Missing_checkpoint_reads_as_null()
+    {
+        Assert.Null(CreateStore().TryGetPlaybackSession("no-such-session"));
+    }
+
     private ListeningActivityStore CreateStore()
         => new(new HarmonieDatabase(Path.Combine(_directory, "jellyfin-harmonie.db")));
 

--- a/tests/Jellyfin.Plugin.Harmonie.Tests/ListeningActivityStoreTests.cs
+++ b/tests/Jellyfin.Plugin.Harmonie.Tests/ListeningActivityStoreTests.cs
@@ -42,7 +42,7 @@ public sealed class ListeningActivityStoreTests : IDisposable
 
         Assert.True(first);
         Assert.False(second);
-        Assert.Equal(2, status.SchemaVersion);
+        Assert.Equal(3, status.SchemaVersion);
         Assert.False(store.IsBootstrapRequired());
 
         using var connection = new HarmonieDatabase(
@@ -79,7 +79,7 @@ public sealed class ListeningActivityStoreTests : IDisposable
 
         var status = store.GetStatus();
 
-        Assert.Equal(2, status.SchemaVersion);
+        Assert.Equal(3, status.SchemaVersion);
         Assert.True(status.SizeBytes > 0);
         Assert.Equal(Path.GetFullPath(Path.Combine(_directory, "jellyfin-harmonie.db")), status.DatabasePath);
 
@@ -416,6 +416,73 @@ public sealed class ListeningActivityStoreTests : IDisposable
         Assert.Contains(metrics, item => item.ItemId == playlistTrack);
     }
 
+    [Fact]
+    public void Completing_playback_replaces_its_checkpoint_without_double_counting()
+    {
+        var store = CreateStore();
+        var userId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        var observedAt = DateTimeOffset.Parse("2026-08-16T12:00:00Z");
+        store.UpsertPlaybackSessions(new[]
+        {
+            Checkpoint(userId, itemId, observedAt),
+        });
+
+        store.CompletePlaybackSession(
+            "session-1",
+            new[]
+            {
+                Playback(
+                    userId,
+                    itemId,
+                    observedAt.AddSeconds(10),
+                    completed: true,
+                    earlySkip: false),
+            });
+
+        using var connection = new HarmonieDatabase(
+            Path.Combine(_directory, "jellyfin-harmonie.db")).OpenConnection();
+        Assert.Equal(0L, Scalar(connection, "SELECT COUNT(*) FROM playback_sessions;"));
+        Assert.Equal(1L, Scalar(connection, "SELECT COUNT(*) FROM playback_events;"));
+        Assert.Equal(1L, Scalar(connection, "SELECT counted_as_play FROM playback_events;"));
+    }
+
+    [Fact]
+    public void Abandoned_checkpoint_is_recovered_after_database_reopen()
+    {
+        var path = Path.Combine(_directory, "jellyfin-harmonie.db");
+        var userId = Guid.NewGuid();
+        var itemId = Guid.NewGuid();
+        var observedAt = DateTimeOffset.Parse("2026-08-16T12:02:50Z");
+        CreateStore().UpsertPlaybackSessions(new[]
+        {
+            Checkpoint(userId, itemId, observedAt),
+        });
+
+        var reopened = new ListeningActivityStore(new HarmonieDatabase(path));
+        var recovered = reopened.RecoverAbandonedPlaybackSessions(observedAt.AddSeconds(1));
+
+        Assert.Equal(1, recovered);
+        using var connection = new HarmonieDatabase(path).OpenConnection();
+        Assert.Equal(0L, Scalar(connection, "SELECT COUNT(*) FROM playback_sessions;"));
+        Assert.Equal(1L, Scalar(connection, "SELECT COUNT(*) FROM playback_events;"));
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT user_id, item_id, stopped_utc, counted_as_play,
+                   play_session_id, client_name, device_id
+            FROM playback_events;
+            """;
+        using var reader = command.ExecuteReader();
+        Assert.True(reader.Read());
+        Assert.Equal(userId.ToString("N"), reader.GetString(0));
+        Assert.Equal(itemId.ToString("N"), reader.GetString(1));
+        Assert.Equal(observedAt, DateTimeOffset.Parse(reader.GetString(2)));
+        Assert.Equal(1, reader.GetInt32(3));
+        Assert.Equal("play-1", reader.GetString(4));
+        Assert.Equal("Finamp", reader.GetString(5));
+        Assert.Equal("phone", reader.GetString(6));
+    }
+
     private ListeningActivityStore CreateStore()
         => new(new HarmonieDatabase(Path.Combine(_directory, "jellyfin-harmonie.db")));
 
@@ -453,4 +520,34 @@ public sealed class ListeningActivityStoreTests : IDisposable
             PlaySessionId: Guid.NewGuid().ToString("N"),
             ClientName: "test",
             DeviceId: "test");
+
+    private static PlaybackSessionCheckpoint Checkpoint(
+        Guid userId,
+        Guid itemId,
+        DateTimeOffset observedAt)
+        => new(
+            SessionKey: "session-1",
+            UserId: userId,
+            ItemId: itemId,
+            StartedUtc: observedAt.AddMinutes(-2).AddSeconds(-50),
+            LastObservedUtc: observedAt,
+            StartPositionTicks: 0,
+            EndPositionTicks: TimeSpan.FromMinutes(2).Add(TimeSpan.FromSeconds(50)).Ticks,
+            MaxPositionTicks: TimeSpan.FromMinutes(2).Add(TimeSpan.FromSeconds(50)).Ticks,
+            ActiveListenTicks: TimeSpan.FromMinutes(2).Add(TimeSpan.FromSeconds(50)).Ticks,
+            SeekForwardCount: 0,
+            SeekBackwardCount: 0,
+            PauseCount: 0,
+            IsPaused: false,
+            DurationTicks: TimeSpan.FromMinutes(3).Ticks,
+            PlaySessionId: "play-1",
+            ClientName: "Finamp",
+            DeviceId: "phone");
+
+    private static long Scalar(Microsoft.Data.Sqlite.SqliteConnection connection, string sql)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        return Convert.ToInt64(command.ExecuteScalar());
+    }
 }

--- a/tests/Jellyfin.Plugin.Harmonie.Tests/ListeningActivityTrackerTests.cs
+++ b/tests/Jellyfin.Plugin.Harmonie.Tests/ListeningActivityTrackerTests.cs
@@ -117,6 +117,52 @@ public class ListeningActivityTrackerTests
     }
 
     [Fact]
+    public void Playback_progress_creates_one_checkpoint_per_distinct_user()
+    {
+        var firstUser = User("first");
+        var secondUser = User("second");
+        var item = new Audio
+        {
+            Id = Guid.NewGuid(),
+            RunTimeTicks = TimeSpan.FromMinutes(3).Ticks,
+        };
+        var eventArgs = new PlaybackProgressEventArgs
+        {
+            Item = item,
+            Users = new List<User> { firstUser, secondUser, firstUser },
+            PlaybackPositionTicks = TimeSpan.FromSeconds(30).Ticks,
+            PlaySessionId = "play-1",
+            ClientName = "Finamp",
+            DeviceId = "phone",
+        };
+        var startedAt = DateTimeOffset.Parse("2026-08-16T10:00:00Z");
+        var session = PlaybackSessionAccumulator.FromStart(startedAt, 0, isPaused: false);
+        session.Observe(
+            startedAt.AddSeconds(30),
+            eventArgs.PlaybackPositionTicks,
+            isPaused: false);
+
+        var checkpoints = ListeningActivityTracker.CreateCheckpoints(
+            eventArgs,
+            "session-1",
+            session);
+
+        Assert.Equal(2, checkpoints.Count);
+        Assert.Contains(checkpoints, checkpoint => checkpoint.UserId == firstUser.Id);
+        Assert.Contains(checkpoints, checkpoint => checkpoint.UserId == secondUser.Id);
+        Assert.All(checkpoints, checkpoint =>
+        {
+            Assert.Equal(item.Id, checkpoint.ItemId);
+            Assert.Equal(item.RunTimeTicks, checkpoint.DurationTicks);
+            Assert.Equal(eventArgs.PlaybackPositionTicks, checkpoint.EndPositionTicks);
+            Assert.Equal(TimeSpan.FromSeconds(30).Ticks, checkpoint.ActiveListenTicks);
+            Assert.Equal("play-1", checkpoint.PlaySessionId);
+            Assert.Equal("Finamp", checkpoint.ClientName);
+            Assert.Equal("phone", checkpoint.DeviceId);
+        });
+    }
+
+    [Fact]
     public void Stale_playback_sessions_are_evicted_without_removing_recent_sessions()
     {
         var now = DateTimeOffset.Parse("2026-08-16T18:00:00Z");

--- a/tests/Jellyfin.Plugin.Harmonie.Tests/PlaybackSessionAccumulatorTests.cs
+++ b/tests/Jellyfin.Plugin.Harmonie.Tests/PlaybackSessionAccumulatorTests.cs
@@ -221,4 +221,111 @@ public sealed class PlaybackSessionAccumulatorTests
         Assert.False(activity.PlayedToCompletion);
         Assert.True(activity.IsEarlySkip);
     }
+
+    [Fact]
+    public void Live_stop_keeps_the_tight_completion_margin_on_short_tracks()
+    {
+        var startedAt = DateTimeOffset.Parse("2026-08-16T10:00:00Z");
+        var session = PlaybackSessionAccumulator.FromStart(startedAt, 0, isPaused: false);
+        var stoppedAt = startedAt.AddSeconds(92);
+
+        var summary = session.Finish(
+            stoppedAt,
+            TimeSpan.FromSeconds(92).Ticks,
+            TimeSpan.FromSeconds(100).Ticks);
+
+        // 8 seconds short of a 100-second track: within the wide recovery
+        // margin but outside the tight live margin (5 seconds).
+        Assert.False(summary.PlayedToCompletion);
+    }
+
+    [Fact]
+    public void Recovered_checkpoint_gets_the_wider_completion_margin()
+    {
+        var startedAt = DateTimeOffset.Parse("2026-08-16T10:00:00Z");
+        var checkpoint = new PlaybackSessionCheckpoint(
+            SessionKey: "session-1",
+            UserId: Guid.NewGuid(),
+            ItemId: Guid.NewGuid(),
+            StartedUtc: startedAt,
+            LastObservedUtc: startedAt.AddSeconds(92),
+            StartPositionTicks: 0,
+            EndPositionTicks: TimeSpan.FromSeconds(92).Ticks,
+            MaxPositionTicks: TimeSpan.FromSeconds(92).Ticks,
+            ActiveListenTicks: TimeSpan.FromSeconds(92).Ticks,
+            SeekForwardCount: 0,
+            SeekBackwardCount: 0,
+            PauseCount: 0,
+            IsPaused: false,
+            DurationTicks: TimeSpan.FromSeconds(100).Ticks,
+            PlaySessionId: "play-1",
+            ClientName: "Finamp",
+            DeviceId: "phone");
+
+        var activity = PlaybackSessionAccumulator.Recover(checkpoint);
+
+        // The same 8-second shortfall counts: a checkpoint's end position
+        // lags the true end by up to one progress report.
+        Assert.True(activity.PlayedToCompletion);
+    }
+
+    [Fact]
+    public void Resuming_from_a_checkpoint_does_not_credit_the_silent_gap()
+    {
+        var startedAt = DateTimeOffset.Parse("2026-08-16T10:00:00Z");
+        var checkpoint = new PlaybackSessionCheckpoint(
+            SessionKey: "session-1",
+            UserId: Guid.NewGuid(),
+            ItemId: Guid.NewGuid(),
+            StartedUtc: startedAt,
+            LastObservedUtc: startedAt.AddSeconds(60),
+            StartPositionTicks: 0,
+            EndPositionTicks: TimeSpan.FromSeconds(60).Ticks,
+            MaxPositionTicks: TimeSpan.FromSeconds(60).Ticks,
+            ActiveListenTicks: TimeSpan.FromSeconds(60).Ticks,
+            SeekForwardCount: 0,
+            SeekBackwardCount: 0,
+            PauseCount: 1,
+            IsPaused: true,
+            DurationTicks: TimeSpan.FromMinutes(3).Ticks,
+            PlaySessionId: "play-1",
+            ClientName: "Finamp",
+            DeviceId: "phone");
+        var resumedAt = startedAt.AddHours(10);
+
+        var session = PlaybackSessionAccumulator.FromCheckpoint(checkpoint, resumedAt);
+        session.Observe(
+            resumedAt.AddSeconds(30),
+            TimeSpan.FromSeconds(90).Ticks,
+            isPaused: false);
+        var summary = session.Finish(
+            resumedAt.AddSeconds(60),
+            TimeSpan.FromSeconds(120).Ticks,
+            TimeSpan.FromMinutes(3).Ticks);
+
+        // 60 seconds before the pause plus 30 after the resume; the
+        // ten-hour gap contributes nothing.
+        Assert.Equal(TimeSpan.FromSeconds(90).Ticks, summary.ActiveListenTicks);
+        Assert.Equal(startedAt, summary.StartedUtc);
+        Assert.Equal(1, summary.PauseCount);
+    }
+
+    [Fact]
+    public void Checkpoints_are_throttled_except_for_state_transitions()
+    {
+        var startedAt = DateTimeOffset.Parse("2026-08-16T10:00:00Z");
+        var session = PlaybackSessionAccumulator.FromStart(startedAt, 0, isPaused: false);
+
+        Assert.True(session.ShouldCheckpoint(startedAt));
+        session.Observe(startedAt.AddSeconds(10), TimeSpan.FromSeconds(10).Ticks, isPaused: false);
+        Assert.False(session.ShouldCheckpoint(startedAt.AddSeconds(10)));
+
+        // A pause transition bypasses the interval.
+        session.Observe(startedAt.AddSeconds(15), TimeSpan.FromSeconds(15).Ticks, isPaused: true);
+        Assert.True(session.ShouldCheckpoint(startedAt.AddSeconds(15)));
+        Assert.False(session.ShouldCheckpoint(startedAt.AddSeconds(20)));
+
+        // The interval elapsing does too.
+        Assert.True(session.ShouldCheckpoint(startedAt.AddSeconds(50)));
+    }
 }

--- a/tests/Jellyfin.Plugin.Harmonie.Tests/PlaybackSessionAccumulatorTests.cs
+++ b/tests/Jellyfin.Plugin.Harmonie.Tests/PlaybackSessionAccumulatorTests.cs
@@ -160,4 +160,65 @@ public sealed class PlaybackSessionAccumulatorTests
         Assert.Null(summary.ActiveListenTicks);
         Assert.False(summary.IsEarlySkip);
     }
+
+    [Fact]
+    public void Recovered_near_complete_session_counts_as_a_play()
+    {
+        var startedAt = DateTimeOffset.Parse("2026-08-16T10:00:00Z");
+        var checkpoint = new PlaybackSessionCheckpoint(
+            SessionKey: "session-1",
+            UserId: Guid.NewGuid(),
+            ItemId: Guid.NewGuid(),
+            StartedUtc: startedAt,
+            LastObservedUtc: startedAt.AddMinutes(2).AddSeconds(50),
+            StartPositionTicks: 0,
+            EndPositionTicks: TimeSpan.FromMinutes(2).Add(TimeSpan.FromSeconds(50)).Ticks,
+            MaxPositionTicks: TimeSpan.FromMinutes(2).Add(TimeSpan.FromSeconds(50)).Ticks,
+            ActiveListenTicks: TimeSpan.FromMinutes(2).Add(TimeSpan.FromSeconds(50)).Ticks,
+            SeekForwardCount: 0,
+            SeekBackwardCount: 0,
+            PauseCount: 0,
+            IsPaused: false,
+            DurationTicks: TimeSpan.FromMinutes(3).Ticks,
+            PlaySessionId: "play-1",
+            ClientName: "Finamp",
+            DeviceId: "phone");
+
+        var activity = PlaybackSessionAccumulator.Recover(checkpoint);
+
+        Assert.True(activity.CountedAsPlay);
+        Assert.True(activity.PlayedToCompletion);
+        Assert.False(activity.IsEarlySkip);
+        Assert.Equal(checkpoint.LastObservedUtc, activity.StoppedUtc);
+    }
+
+    [Fact]
+    public void Recovered_seek_to_end_does_not_count_as_a_play()
+    {
+        var startedAt = DateTimeOffset.Parse("2026-08-16T10:00:00Z");
+        var checkpoint = new PlaybackSessionCheckpoint(
+            SessionKey: "session-1",
+            UserId: Guid.NewGuid(),
+            ItemId: Guid.NewGuid(),
+            StartedUtc: startedAt,
+            LastObservedUtc: startedAt.AddSeconds(8),
+            StartPositionTicks: 0,
+            EndPositionTicks: TimeSpan.FromMinutes(3).Ticks,
+            MaxPositionTicks: TimeSpan.FromMinutes(3).Ticks,
+            ActiveListenTicks: TimeSpan.FromSeconds(8).Ticks,
+            SeekForwardCount: 1,
+            SeekBackwardCount: 0,
+            PauseCount: 0,
+            IsPaused: false,
+            DurationTicks: TimeSpan.FromMinutes(3).Ticks,
+            PlaySessionId: "play-1",
+            ClientName: "Finamp",
+            DeviceId: "phone");
+
+        var activity = PlaybackSessionAccumulator.Recover(checkpoint);
+
+        Assert.False(activity.CountedAsPlay);
+        Assert.False(activity.PlayedToCompletion);
+        Assert.True(activity.IsEarlySkip);
+    }
 }

--- a/tests/Jellyfin.Plugin.Harmonie.Tests/PlaybackSessionAccumulatorTests.cs
+++ b/tests/Jellyfin.Plugin.Harmonie.Tests/PlaybackSessionAccumulatorTests.cs
@@ -316,16 +316,54 @@ public sealed class PlaybackSessionAccumulatorTests
         var startedAt = DateTimeOffset.Parse("2026-08-16T10:00:00Z");
         var session = PlaybackSessionAccumulator.FromStart(startedAt, 0, isPaused: false);
 
-        Assert.True(session.ShouldCheckpoint(startedAt));
+        var duration = TimeSpan.FromMinutes(10).Ticks;
+        Assert.True(session.ShouldCheckpoint(startedAt, duration));
         session.Observe(startedAt.AddSeconds(10), TimeSpan.FromSeconds(10).Ticks, isPaused: false);
-        Assert.False(session.ShouldCheckpoint(startedAt.AddSeconds(10)));
+        Assert.False(session.ShouldCheckpoint(startedAt.AddSeconds(10), duration));
 
         // A pause transition bypasses the interval.
         session.Observe(startedAt.AddSeconds(15), TimeSpan.FromSeconds(15).Ticks, isPaused: true);
-        Assert.True(session.ShouldCheckpoint(startedAt.AddSeconds(15)));
-        Assert.False(session.ShouldCheckpoint(startedAt.AddSeconds(20)));
+        Assert.True(session.ShouldCheckpoint(startedAt.AddSeconds(15), duration));
+        Assert.False(session.ShouldCheckpoint(startedAt.AddSeconds(20), duration));
 
         // The interval elapsing does too.
-        Assert.True(session.ShouldCheckpoint(startedAt.AddSeconds(50)));
+        Assert.True(session.ShouldCheckpoint(startedAt.AddSeconds(50), duration));
+    }
+
+    [Fact]
+    public void Near_complete_play_is_counted_despite_checkpoint_throttling()
+    {
+        var startedAt = DateTimeOffset.Parse("2026-08-16T10:00:00Z");
+        var duration = TimeSpan.FromSeconds(180).Ticks;
+        var session = PlaybackSessionAccumulator.FromStart(startedAt, 0, isPaused: false);
+        PlaybackSessionCheckpoint? lastCheckpoint = null;
+
+        // Progress events every ten seconds until the client dies at 170s,
+        // checkpointing exactly when the throttle allows.
+        for (var second = 0; second <= 170; second += 10)
+        {
+            var at = startedAt.AddSeconds(second);
+            session.Observe(at, TimeSpan.FromSeconds(second).Ticks, isPaused: false);
+            if (session.ShouldCheckpoint(at, duration))
+            {
+                lastCheckpoint = session.CreateCheckpoint(
+                    "session-1",
+                    Guid.NewGuid(),
+                    Guid.NewGuid(),
+                    duration,
+                    "play-1",
+                    "Finamp",
+                    "phone");
+            }
+        }
+
+        Assert.NotNull(lastCheckpoint);
+        var activity = PlaybackSessionAccumulator.Recover(lastCheckpoint);
+
+        // The end zone tightens the checkpoint interval, so the persisted
+        // position must be close enough to the end to count the play.
+        Assert.Equal(TimeSpan.FromSeconds(170).Ticks, lastCheckpoint.EndPositionTicks);
+        Assert.True(activity.CountedAsPlay);
+        Assert.True(activity.PlayedToCompletion);
     }
 }


### PR DESCRIPTION
Persist playback progress as durable checkpoints so listens survive clients that die without a stop signal, server crashes, and long pauses.
