### PR TITLE
fix: record the previous track when a session switches

### DIFF
--- a/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/ListeningActivityTracker.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/ListeningActivityTracker.cs
@@ -316,6 +316,11 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         var current = new ActiveSessionTrack(
             key,
             audio.Id,
+            eventArgs.Users
+                .Select(user => user.Id)
+                .Where(userId => userId != Guid.Empty)
+                .Distinct()
+                .ToArray(),
             audio.RunTimeTicks,
             eventArgs.PlaySessionId,
             eventArgs.ClientName,
@@ -343,11 +348,7 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
 
         _completedKeys[previous.Key] = now;
         var summary = session.Finish(now, null, previous.DurationTicks);
-        var activities = CreateSwitchActivities(
-            eventArgs.Users,
-            previous,
-            summary,
-            now);
+        var activities = CreateSwitchActivities(previous, summary, now);
         if (!_writes.Writer.TryWrite(
                 new CompletePlaybackWrite(previous.Key, session.Generation, activities)))
         {
@@ -363,18 +364,15 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
     /// same heuristic recovery uses.
     /// </summary>
     internal static IReadOnlyList<ListeningActivityEvent> CreateSwitchActivities(
-        IReadOnlyList<User> users,
         ActiveSessionTrack track,
         PlaybackSessionSummary summary,
         DateTimeOffset stoppedAt)
     {
-        ArgumentNullException.ThrowIfNull(users);
         ArgumentNullException.ThrowIfNull(track);
         ArgumentNullException.ThrowIfNull(summary);
-        return users
-            .Select(user => user.Id)
-            .Where(userId => userId != Guid.Empty)
-            .Distinct()
+        // The users captured when the track registered, not the new track's:
+        // the session's user can change between the two.
+        return track.UserIds
             .Select(userId => new ListeningActivityEvent(
                 userId,
                 track.ItemId,
@@ -669,16 +667,28 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         }
     }
 
-    private static string? ActivityKey(PlaybackProgressEventArgs eventArgs)
+    /// <summary>
+    /// The tracking key for one track's playback. Item-specific on purpose:
+    /// some clients reuse one play session id for a whole queue, and a key
+    /// without the item would make consecutive tracks overwrite each other.
+    /// </summary>
+    internal static string? ActivityKey(PlaybackProgressEventArgs eventArgs)
     {
-        if (!string.IsNullOrWhiteSpace(eventArgs.PlaySessionId))
+        ArgumentNullException.ThrowIfNull(eventArgs);
+        if (eventArgs.Item is null)
         {
-            return eventArgs.PlaySessionId;
+            return null;
         }
 
-        if (eventArgs.Session is not null && eventArgs.Item is not null)
+        var item = eventArgs.Item.Id.ToString("N");
+        if (!string.IsNullOrWhiteSpace(eventArgs.PlaySessionId))
         {
-            return string.Concat(eventArgs.Session.Id, ":", eventArgs.Item.Id.ToString("N"));
+            return string.Concat(eventArgs.PlaySessionId, ":", item);
+        }
+
+        if (eventArgs.Session is not null)
+        {
+            return string.Concat(eventArgs.Session.Id, ":", item);
         }
 
         return null;
@@ -701,6 +711,7 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
     internal sealed record ActiveSessionTrack(
         string Key,
         Guid ItemId,
+        IReadOnlyList<Guid> UserIds,
         long? DurationTicks,
         string? PlaySessionId,
         string? ClientName,

--- a/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/ListeningActivityTracker.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/ListeningActivityTracker.cs
@@ -53,6 +53,14 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
     private readonly ConcurrentDictionary<string, DateTimeOffset> _completedKeys =
         new(StringComparer.Ordinal);
 
+    // Which track each Jellyfin session is currently playing. Some clients
+    // never send a stop when the user taps another track; the next track's
+    // events are the only signal the previous listen ended, so a switch
+    // finalizes the previous track immediately instead of leaving it to the
+    // 24-hour checkpoint recovery.
+    private readonly ConcurrentDictionary<string, ActiveSessionTrack> _activeTracks =
+        new(StringComparer.Ordinal);
+
     private readonly CancellationTokenSource _shutdown = new();
 
     private Task? _writerTask;
@@ -150,6 +158,7 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         await AwaitWorkerAsync(_writerTask, cancellationToken).ConfigureAwait(false);
         _sessions.Clear();
         _completedKeys.Clear();
+        _activeTracks.Clear();
         _started = false;
         _stopped = true;
     }
@@ -178,6 +187,7 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
             var now = DateTimeOffset.UtcNow;
             SweepStaleSessions(now);
             _completedKeys.TryRemove(key, out _);
+            FinalizeSwitchedTrack(eventArgs, key, now);
             var session = PlaybackSessionAccumulator.FromStart(
                 now,
                 eventArgs.PlaybackPositionTicks,
@@ -199,6 +209,7 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         {
             var now = DateTimeOffset.UtcNow;
             SweepStaleSessions(now);
+            FinalizeSwitchedTrack(eventArgs, key, now);
             PlaybackSessionAccumulator session;
             if (_sessions.TryGetValue(key, out var existing))
             {
@@ -264,6 +275,13 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         }
 
         _completedKeys[key] = now;
+        if (eventArgs.Session?.Id is { } stoppedSessionId
+            && _activeTracks.TryGetValue(stoppedSessionId, out var active)
+            && active.Key == key)
+        {
+            _activeTracks.TryRemove(
+                new KeyValuePair<string, ActiveSessionTrack>(stoppedSessionId, active));
+        }
 
         var summary = session.Finish(
             now,
@@ -277,6 +295,109 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
                 "Could not queue listening activity for item {ItemId}; the tracker is stopping.",
                 audio.Id);
         }
+    }
+
+    /// <summary>
+    /// Records which track a Jellyfin session is playing; when the session
+    /// switches to a different track, finalizes the previous one as if a
+    /// stop had arrived. Runs before the new track's accumulator is touched.
+    /// </summary>
+    private void FinalizeSwitchedTrack(
+        PlaybackProgressEventArgs eventArgs,
+        string key,
+        DateTimeOffset now)
+    {
+        if (eventArgs.Session?.Id is not { } jellyfinSessionId
+            || eventArgs.Item is not Audio audio)
+        {
+            return;
+        }
+
+        var current = new ActiveSessionTrack(
+            key,
+            audio.Id,
+            audio.RunTimeTicks,
+            eventArgs.PlaySessionId,
+            eventArgs.ClientName,
+            eventArgs.DeviceId);
+        if (!_activeTracks.TryGetValue(jellyfinSessionId, out var previous))
+        {
+            _activeTracks[jellyfinSessionId] = current;
+            return;
+        }
+
+        if (previous.Key == key)
+        {
+            return;
+        }
+
+        _activeTracks[jellyfinSessionId] = current;
+        if (!_sessions.TryRemove(previous.Key, out var session))
+        {
+            session = ResumeFromCheckpoint(previous.Key, now);
+            if (session is null)
+            {
+                return;
+            }
+        }
+
+        _completedKeys[previous.Key] = now;
+        var summary = session.Finish(now, null, previous.DurationTicks);
+        var activities = CreateSwitchActivities(
+            eventArgs.Users,
+            previous,
+            summary,
+            now);
+        if (!_writes.Writer.TryWrite(
+                new CompletePlaybackWrite(previous.Key, session.Generation, activities)))
+        {
+            _logger.LogWarning(
+                "Could not queue the switched-away track for session {SessionKey}; the tracker is stopping.",
+                previous.Key);
+        }
+    }
+
+    /// <summary>
+    /// Builds the playback events for a track the user switched away from.
+    /// No stop event exists, so the play-count judgment falls back to the
+    /// same heuristic recovery uses.
+    /// </summary>
+    internal static IReadOnlyList<ListeningActivityEvent> CreateSwitchActivities(
+        IReadOnlyList<User> users,
+        ActiveSessionTrack track,
+        PlaybackSessionSummary summary,
+        DateTimeOffset stoppedAt)
+    {
+        ArgumentNullException.ThrowIfNull(users);
+        ArgumentNullException.ThrowIfNull(track);
+        ArgumentNullException.ThrowIfNull(summary);
+        return users
+            .Select(user => user.Id)
+            .Where(userId => userId != Guid.Empty)
+            .Distinct()
+            .Select(userId => new ListeningActivityEvent(
+                userId,
+                track.ItemId,
+                summary.StartedUtc,
+                stoppedAt,
+                summary.StartPositionTicks,
+                summary.EndPositionTicks,
+                summary.MaxPositionTicks,
+                summary.ActiveListenTicks,
+                summary.SeekForwardCount,
+                summary.SeekBackwardCount,
+                summary.PauseCount,
+                summary.IsEarlySkip,
+                track.DurationTicks,
+                summary.PlayedToCompletion,
+                PlaybackSessionAccumulator.IsCountedAsPlay(
+                    summary.EndPositionTicks,
+                    summary.ActiveListenTicks,
+                    track.DurationTicks),
+                track.PlaySessionId,
+                track.ClientName,
+                track.DeviceId))
+            .ToList();
     }
 
     private PlaybackSessionAccumulator? ResumeFromCheckpoint(
@@ -524,6 +645,15 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
         }
 
         var removed = EvictStaleSessions(_sessions, observedAt - SessionRetention);
+        foreach (var entry in _activeTracks)
+        {
+            if (!_sessions.ContainsKey(entry.Value.Key))
+            {
+                ((ICollection<KeyValuePair<string, ActiveSessionTrack>>)_activeTracks)
+                    .Remove(entry);
+            }
+        }
+
         foreach (var entry in _completedKeys)
         {
             if (entry.Value < observedAt - CompletedKeyRetention)
@@ -563,6 +693,18 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
 
         await task.WaitAsync(cancellationToken).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// The track a Jellyfin session is currently playing, with everything
+    /// needed to finalize it when the session switches tracks.
+    /// </summary>
+    internal sealed record ActiveSessionTrack(
+        string Key,
+        Guid ItemId,
+        long? DurationTicks,
+        string? PlaySessionId,
+        string? ClientName,
+        string? DeviceId);
 
     private abstract record ListeningActivityWrite;
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -27,7 +27,7 @@ abandoned session is recovered from its checkpoint.
 | `is_early_skip` | 1 when active listening stayed under `min(30s, duration / 5)` and the track did not complete. |
 | `duration_ticks` | The track's runtime. |
 | `played_to_completion` | 1 when the end position reached the track end (within `min(10s, duration / 20)` live; a wider `duration / 5` margin for recovered sessions) and at least half the track was actively listened. The listening floor stops a seek to the end from counting. |
-| `counted_as_play` | 1 when the listen counts toward play counts. Live stops take Jellyfin's own judgment, the same one that raises the user's play count. Recovered sessions use a stand-in: at least half the track actively listened, and either the position within 10 seconds of the end or 90% of the track listened. |
+| `counted_as_play` | 1 when the listen counts toward play counts. Live stops take Jellyfin's own judgment, the same one that raises the user's play count. Recovered sessions and tracks the user switched away from without a stop use a stand-in: at least half the track actively listened, and either the position within 10 seconds of the end or 90% of the track listened. |
 | `play_session_id` | The client's play session id, when it sent one. |
 | `client_name` | The reporting client, such as `Finamp`. |
 | `device_id` | The reporting device. |

--- a/tests/Jellyfin.Plugin.Harmonie.Tests/ListeningActivityTrackerTests.cs
+++ b/tests/Jellyfin.Plugin.Harmonie.Tests/ListeningActivityTrackerTests.cs
@@ -163,6 +163,44 @@ public class ListeningActivityTrackerTests
     }
 
     [Fact]
+    public void Switching_tracks_finalizes_the_previous_track_as_a_play()
+    {
+        var user = User("listener");
+        var itemId = Guid.NewGuid();
+        var startedAt = DateTimeOffset.Parse("2026-08-17T10:00:00Z");
+        var duration = TimeSpan.FromMinutes(3).Ticks;
+        var session = PlaybackSessionAccumulator.FromStart(startedAt, 0, isPaused: false);
+        session.Observe(
+            startedAt.AddSeconds(175),
+            TimeSpan.FromSeconds(175).Ticks,
+            isPaused: false);
+        var switchedAt = startedAt.AddSeconds(176);
+        var summary = session.Finish(switchedAt, null, duration);
+
+        var activities = ListeningActivityTracker.CreateSwitchActivities(
+            new List<User> { user, user },
+            new ListeningActivityTracker.ActiveSessionTrack(
+                "session-1:item",
+                itemId,
+                duration,
+                null,
+                "Finamp",
+                "phone"),
+            summary,
+            switchedAt);
+
+        var activity = Assert.Single(activities);
+        Assert.Equal(user.Id, activity.UserId);
+        Assert.Equal(itemId, activity.ItemId);
+        Assert.Equal(switchedAt, activity.StoppedUtc);
+        // 175 of 180 seconds actively listened: counts as a play without
+        // any stop event from the client.
+        Assert.True(activity.CountedAsPlay);
+        Assert.False(activity.IsEarlySkip);
+        Assert.Equal("Finamp", activity.ClientName);
+    }
+
+    [Fact]
     public void Stale_playback_sessions_are_evicted_without_removing_recent_sessions()
     {
         var now = DateTimeOffset.Parse("2026-08-16T18:00:00Z");

--- a/tests/Jellyfin.Plugin.Harmonie.Tests/ListeningActivityTrackerTests.cs
+++ b/tests/Jellyfin.Plugin.Harmonie.Tests/ListeningActivityTrackerTests.cs
@@ -178,10 +178,10 @@ public class ListeningActivityTrackerTests
         var summary = session.Finish(switchedAt, null, duration);
 
         var activities = ListeningActivityTracker.CreateSwitchActivities(
-            new List<User> { user, user },
             new ListeningActivityTracker.ActiveSessionTrack(
                 "session-1:item",
                 itemId,
+                new[] { user.Id },
                 duration,
                 null,
                 "Finamp",
@@ -198,6 +198,33 @@ public class ListeningActivityTrackerTests
         Assert.True(activity.CountedAsPlay);
         Assert.False(activity.IsEarlySkip);
         Assert.Equal("Finamp", activity.ClientName);
+    }
+
+    [Fact]
+    public void Tracks_sharing_one_play_session_id_get_distinct_keys()
+    {
+        var first = new PlaybackProgressEventArgs
+        {
+            Item = new Audio { Id = Guid.NewGuid() },
+            Users = new List<User>(),
+            PlaySessionId = "queue-play-1",
+        };
+        var second = new PlaybackProgressEventArgs
+        {
+            Item = new Audio { Id = Guid.NewGuid() },
+            Users = new List<User>(),
+            PlaySessionId = "queue-play-1",
+        };
+
+        var firstKey = ListeningActivityTracker.ActivityKey(first);
+        var secondKey = ListeningActivityTracker.ActivityKey(second);
+
+        // A queue that reuses one play session id must not collapse
+        // consecutive tracks into one key: the second track's start would
+        // silently overwrite the first track's listen.
+        Assert.NotNull(firstKey);
+        Assert.NotNull(secondKey);
+        Assert.NotEqual(firstKey, secondKey);
     }
 
     [Fact]


### PR DESCRIPTION
Stale sessions got previously stuck in `playback_sessions` for 24 hours. 