### PR TITLE
fix: unify play counting

### DIFF
--- a/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/ListeningActivityTracker.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/ListeningActivityTracker.cs
@@ -391,7 +391,9 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
                 PlaybackSessionAccumulator.IsCountedAsPlay(
                     summary.EndPositionTicks,
                     summary.ActiveListenTicks,
-                    track.DurationTicks),
+                    track.DurationTicks,
+                    summary.StartPositionTicks,
+                    summary.SeekForwardCount),
                 track.PlaySessionId,
                 track.ClientName,
                 track.DeviceId))
@@ -504,7 +506,9 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
                 PlaybackSessionAccumulator.IsCountedAsPlay(
                     summary.EndPositionTicks,
                     summary.ActiveListenTicks,
-                    audio.RunTimeTicks),
+                    audio.RunTimeTicks,
+                    summary.StartPositionTicks,
+                    summary.SeekForwardCount),
                 eventArgs.PlaySessionId,
                 eventArgs.ClientName,
                 eventArgs.DeviceId))

--- a/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/ListeningActivityTracker.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/ListeningActivityTracker.cs
@@ -501,7 +501,10 @@ internal sealed class ListeningActivityTracker : IHostedService, IDisposable
                 summary.IsEarlySkip,
                 audio.RunTimeTicks,
                 summary.PlayedToCompletion,
-                eventArgs.PlayedToCompletion,
+                PlaybackSessionAccumulator.IsCountedAsPlay(
+                    summary.EndPositionTicks,
+                    summary.ActiveListenTicks,
+                    audio.RunTimeTicks),
                 eventArgs.PlaySessionId,
                 eventArgs.ClientName,
                 eventArgs.DeviceId))

--- a/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/PlaybackSessionAccumulator.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/ListeningActivity/PlaybackSessionAccumulator.cs
@@ -31,6 +31,11 @@ internal sealed class PlaybackSessionAccumulator
     private static readonly long SeekThresholdTicks = TimeSpan.FromSeconds(10).Ticks;
     private static readonly long EarlySkipLimitTicks = TimeSpan.FromSeconds(30).Ticks;
     private static readonly long CompletionToleranceLimitTicks = TimeSpan.FromSeconds(10).Ticks;
+
+    // How close to the track end playback must stop for the listen to count.
+    // Separate from the completion tolerance above: completion describes the
+    // track finishing, this decides whether a play is credited.
+    private static readonly long PlayEndToleranceTicks = TimeSpan.FromSeconds(10).Ticks;
     private static readonly TimeSpan CheckpointWriteInterval = TimeSpan.FromSeconds(30);
 
     // Near the end of a track the durable state must not lag: recovery
@@ -249,29 +254,56 @@ internal sealed class PlaybackSessionAccumulator
             IsCountedAsPlay(
                 checkpoint.EndPositionTicks,
                 checkpoint.ActiveListenTicks,
-                checkpoint.DurationTicks),
+                checkpoint.DurationTicks,
+                checkpoint.StartPositionTicks,
+                checkpoint.SeekForwardCount),
             checkpoint.PlaySessionId,
             checkpoint.ClientName,
             checkpoint.DeviceId);
     }
 
+    /// <summary>
+    /// True when a listen counts toward play counts.
+    ///
+    /// <para>
+    /// With active listening time known, at least half the track must have
+    /// been listened to, and playback must either end within ten seconds of
+    /// the track end or cover nine tenths of the track.
+    /// </para>
+    /// <para>
+    /// Active listening is unknown when no start event was seen: some clients
+    /// report progress without a start, and a session already playing when
+    /// the plugin loads has no start either. Positions and seek counts are
+    /// still measured in that case, so the listen counts when playback ran
+    /// from the first observed position through to the end without jumping
+    /// ahead. Joining by the halfway mark leaves at least half the track
+    /// played in real time, the same floor the measured rule applies.
+    /// </para>
+    /// </summary>
     internal static bool IsCountedAsPlay(
         long? endPositionTicks,
         long? activeListenTicks,
-        long? durationTicks)
+        long? durationTicks,
+        long? startPositionTicks,
+        int seekForwardCount)
     {
-        if (endPositionTicks is null
-            || activeListenTicks is null
-            || durationTicks is null
-            || durationTicks <= 0
-            || activeListenTicks < durationTicks / 2)
+        if (endPositionTicks is null || durationTicks is null || durationTicks <= 0)
         {
             return false;
         }
 
-        var remainingTicks = Math.Max(0, durationTicks.Value - endPositionTicks.Value);
-        return remainingTicks <= TimeSpan.FromSeconds(10).Ticks
-            || activeListenTicks.Value >= durationTicks.Value * 0.9;
+        var reachedEnd = durationTicks.Value - endPositionTicks.Value <= PlayEndToleranceTicks;
+
+        if (activeListenTicks is not null)
+        {
+            return activeListenTicks >= durationTicks / 2
+                && (reachedEnd || activeListenTicks.Value >= durationTicks.Value * 0.9);
+        }
+
+        return reachedEnd
+            && seekForwardCount == 0
+            && startPositionTicks is not null
+            && startPositionTicks.Value <= durationTicks.Value / 2;
     }
 
     private PlaybackSessionSummary CreateSummary(long? durationTicks)

--- a/Jellyfin.Plugin.Harmonie/Services/Storage/HarmonieDatabaseMigrations.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/Storage/HarmonieDatabaseMigrations.cs
@@ -11,5 +11,6 @@ internal static class HarmonieDatabaseMigrations
             new Migration001ListeningActivity(),
             new Migration002RecommendationMetricsIndex(),
             new Migration003PlaybackSessionCheckpoints(),
+            new Migration004UnifiedPlayCounting(),
         };
 }

--- a/Jellyfin.Plugin.Harmonie/Services/Storage/Migrations/Migration004UnifiedPlayCounting.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/Storage/Migrations/Migration004UnifiedPlayCounting.cs
@@ -2,6 +2,19 @@ using Microsoft.Data.Sqlite;
 
 namespace Jellyfin.Plugin.Harmonie.Services.Storage.Migrations;
 
+/// <summary>
+/// Rewrites <c>counted_as_play</c> so every historical row follows the rule
+/// in <c>PlaybackSessionAccumulator.IsCountedAsPlay</c>. Rows written before
+/// this version took Jellyfin's completion flag on live stops and the derived
+/// rule elsewhere, so the column meant two different things.
+/// </summary>
+/// <remarks>
+/// The SQL mirrors <c>IsCountedAsPlay</c> as it stood at schema version 4,
+/// including the truncating <c>duration_ticks / 2</c> and the ten-second end
+/// tolerance of 100,000,000 ticks. It is a record of that rule, not a
+/// reference to it: if the rule changes later, this migration must stay as
+/// it is and a new one must reclassify again.
+/// </remarks>
 internal sealed class Migration004UnifiedPlayCounting : IHarmonieDatabaseMigration
 {
     public int Version => 4;
@@ -13,15 +26,24 @@ internal sealed class Migration004UnifiedPlayCounting : IHarmonieDatabaseMigrati
         command.CommandText = """
             UPDATE playback_events
             SET counted_as_play = CASE
-                WHEN end_position_ticks IS NOT NULL
-                    AND active_listen_ticks IS NOT NULL
-                    AND duration_ticks IS NOT NULL
-                    AND duration_ticks > 0
-                    AND active_listen_ticks >= duration_ticks / 2
-                    AND (
-                        end_position_ticks >= duration_ticks - 100000000
-                        OR active_listen_ticks >= duration_ticks * 0.9
-                    )
+                WHEN end_position_ticks IS NULL
+                    OR duration_ticks IS NULL
+                    OR duration_ticks <= 0
+                THEN 0
+                WHEN active_listen_ticks IS NOT NULL
+                THEN CASE
+                    WHEN active_listen_ticks >= duration_ticks / 2
+                        AND (
+                            duration_ticks - end_position_ticks <= 100000000
+                            OR active_listen_ticks >= duration_ticks * 0.9
+                        )
+                    THEN 1
+                    ELSE 0
+                END
+                WHEN duration_ticks - end_position_ticks <= 100000000
+                    AND seek_forward_count = 0
+                    AND start_position_ticks IS NOT NULL
+                    AND start_position_ticks <= duration_ticks / 2
                 THEN 1
                 ELSE 0
             END;

--- a/Jellyfin.Plugin.Harmonie/Services/Storage/Migrations/Migration004UnifiedPlayCounting.cs
+++ b/Jellyfin.Plugin.Harmonie/Services/Storage/Migrations/Migration004UnifiedPlayCounting.cs
@@ -1,0 +1,31 @@
+using Microsoft.Data.Sqlite;
+
+namespace Jellyfin.Plugin.Harmonie.Services.Storage.Migrations;
+
+internal sealed class Migration004UnifiedPlayCounting : IHarmonieDatabaseMigration
+{
+    public int Version => 4;
+
+    public void Apply(SqliteConnection connection, SqliteTransaction transaction)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            UPDATE playback_events
+            SET counted_as_play = CASE
+                WHEN end_position_ticks IS NOT NULL
+                    AND active_listen_ticks IS NOT NULL
+                    AND duration_ticks IS NOT NULL
+                    AND duration_ticks > 0
+                    AND active_listen_ticks >= duration_ticks / 2
+                    AND (
+                        end_position_ticks >= duration_ticks - 100000000
+                        OR active_listen_ticks >= duration_ticks * 0.9
+                    )
+                THEN 1
+                ELSE 0
+            END;
+            """;
+        command.ExecuteNonQuery();
+    }
+}

--- a/docs/database.md
+++ b/docs/database.md
@@ -27,7 +27,7 @@ abandoned session is recovered from its checkpoint.
 | `is_early_skip` | 1 when active listening stayed under `min(30s, duration / 5)` and the track did not complete. |
 | `duration_ticks` | The track's runtime. |
 | `played_to_completion` | 1 when the end position reached the track end (within `min(10s, duration / 20)` live; a wider `duration / 5` margin for recovered sessions) and at least half the track was actively listened. The listening floor stops a seek to the end from counting. |
-| `counted_as_play` | 1 when the listen counts toward play counts. Live stops take Jellyfin's own judgment, the same one that raises the user's play count. Recovered sessions and tracks the user switched away from without a stop use a stand-in: at least half the track actively listened, and either the position within 10 seconds of the end or 90% of the track listened. |
+| `counted_as_play` | 1 when at least half the track was actively listened to, and playback either ended within the final 10 seconds or active listening covered at least 90% of the track. The same rule applies to reported stops, switched tracks, and recovered sessions. |
 | `play_session_id` | The client's play session id, when it sent one. |
 | `client_name` | The reporting client, such as `Finamp`. |
 | `device_id` | The reporting device. |

--- a/docs/database.md
+++ b/docs/database.md
@@ -27,7 +27,7 @@ abandoned session is recovered from its checkpoint.
 | `is_early_skip` | 1 when active listening stayed under `min(30s, duration / 5)` and the track did not complete. |
 | `duration_ticks` | The track's runtime. |
 | `played_to_completion` | 1 when the end position reached the track end (within `min(10s, duration / 20)` live; a wider `duration / 5` margin for recovered sessions) and at least half the track was actively listened. The listening floor stops a seek to the end from counting. |
-| `counted_as_play` | 1 when at least half the track was actively listened to, and playback either ended within the final 10 seconds or active listening covered at least 90% of the track. The same rule applies to reported stops, switched tracks, and recovered sessions. |
+| `counted_as_play` | 1 when at least half the track was actively listened to, and playback either ended within the final 10 seconds or active listening covered at least 90% of the track. When active listening is unknown, because no start event was seen, the listen counts instead when playback ran from `start_position_ticks` to within 10 seconds of the end with no forward seeks, and that starting point was no later than halfway. The same rules apply to reported stops, switched tracks, and recovered sessions. |
 | `play_session_id` | The client's play session id, when it sent one. |
 | `client_name` | The reporting client, such as `Finamp`. |
 | `device_id` | The reporting device. |

--- a/tests/Jellyfin.Plugin.Harmonie.Tests/HarmonieDatabaseTests.cs
+++ b/tests/Jellyfin.Plugin.Harmonie.Tests/HarmonieDatabaseTests.cs
@@ -76,7 +76,7 @@ public sealed class HarmonieDatabaseTests : IDisposable
     }
 
     [Fact]
-    public void Recommendation_index_and_checkpoint_table_are_added_when_schema_one_is_upgraded()
+    public void Later_schema_changes_are_added_when_schema_one_is_upgraded()
     {
         var path = Path.Combine(_directory, "jellyfin-harmonie.db");
         new HarmonieDatabase(
@@ -97,7 +97,7 @@ public sealed class HarmonieDatabaseTests : IDisposable
             columns.Add(reader.GetString(2));
         }
 
-        Assert.Equal(3, upgraded.SchemaVersion);
+        Assert.Equal(4, upgraded.SchemaVersion);
         Assert.Equal(new[] { "user_id", "item_id", "stopped_utc" }, columns);
 
         using var tableCommand = connection.CreateCommand();
@@ -107,6 +107,65 @@ public sealed class HarmonieDatabaseTests : IDisposable
             WHERE type = 'table' AND name = 'playback_sessions';
             """;
         Assert.Equal(1L, tableCommand.ExecuteScalar());
+    }
+
+    [Fact]
+    public void Unified_play_counting_migration_reclassifies_existing_events()
+    {
+        var path = Path.Combine(_directory, "jellyfin-harmonie.db");
+        new HarmonieDatabase(
+            path,
+            new IHarmonieDatabaseMigration[]
+            {
+                new Migration001ListeningActivity(),
+                new Migration002RecommendationMetricsIndex(),
+                new Migration003PlaybackSessionCheckpoints(),
+            }).Initialize();
+
+        using (var connection = new HarmonieDatabase(
+                   path,
+                   new IHarmonieDatabaseMigration[]
+                   {
+                       new Migration001ListeningActivity(),
+                       new Migration002RecommendationMetricsIndex(),
+                       new Migration003PlaybackSessionCheckpoints(),
+                   }).OpenConnection())
+        {
+            using var command = connection.CreateCommand();
+            command.CommandText = """
+                INSERT INTO playback_events (
+                    user_id, item_id, stopped_utc, end_position_ticks,
+                    active_listen_ticks, seek_forward_count,
+                    seek_backward_count, pause_count, is_early_skip,
+                    duration_ticks, played_to_completion, counted_as_play)
+                VALUES
+                    ('user', 'short', '2026-08-18T10:00:00Z', 200000000,
+                     200000000, 0, 0, 0, 1, 2400000000, 0, 1),
+                    ('user', 'ninety-percent', '2026-08-18T10:01:00Z', 2200000000,
+                     2200000000, 0, 0, 0, 0, 2400000000, 0, 0),
+                    ('user', 'near-end', '2026-08-18T10:02:00Z', 2350000000,
+                     1200000000, 0, 0, 0, 0, 2400000000, 0, 0),
+                    ('user', 'unknown', '2026-08-18T10:03:00Z', NULL,
+                     NULL, 0, 0, 0, 0, 2400000000, 1, 1);
+                """;
+            command.ExecuteNonQuery();
+        }
+
+        var upgraded = new HarmonieDatabase(path);
+        upgraded.Initialize();
+
+        using var upgradedConnection = upgraded.OpenConnection();
+        using var resultCommand = upgradedConnection.CreateCommand();
+        resultCommand.CommandText = "SELECT counted_as_play FROM playback_events ORDER BY id;";
+        using var reader = resultCommand.ExecuteReader();
+        var results = new List<long>();
+        while (reader.Read())
+        {
+            results.Add(reader.GetInt64(0));
+        }
+
+        Assert.Equal(4, upgraded.SchemaVersion);
+        Assert.Equal(new long[] { 0, 1, 1, 0 }, results);
     }
 
     private sealed class RecordingMigration : IHarmonieDatabaseMigration

--- a/tests/Jellyfin.Plugin.Harmonie.Tests/HarmonieDatabaseTests.cs
+++ b/tests/Jellyfin.Plugin.Harmonie.Tests/HarmonieDatabaseTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Jellyfin.Plugin.Harmonie.Services.ListeningActivity;
 using Jellyfin.Plugin.Harmonie.Services.Storage;
 using Jellyfin.Plugin.Harmonie.Services.Storage.Migrations;
 using Microsoft.Data.Sqlite;
@@ -166,6 +167,111 @@ public sealed class HarmonieDatabaseTests : IDisposable
 
         Assert.Equal(4, upgraded.SchemaVersion);
         Assert.Equal(new long[] { 0, 1, 1, 0 }, results);
+    }
+
+    /// <summary>
+    /// The migration restates <see cref="PlaybackSessionAccumulator.IsCountedAsPlay"/>
+    /// in SQL, and two copies of one rule drift apart silently. Every row it
+    /// rewrites is checked against the method itself.
+    /// </summary>
+    [Fact]
+    public void Unified_play_counting_migration_matches_the_counting_rule()
+    {
+        var duration = TimeSpan.FromMinutes(4).Ticks;
+        var halfway = duration / 2;
+        var tenSeconds = TimeSpan.FromSeconds(10).Ticks;
+
+        // end, active, duration, start, seekForward — one row per branch of
+        // the rule, including rows the CASE cannot decide.
+        var rows = new (long? End, long? Active, long? Duration, long? Start, int Seek)[]
+        {
+            (duration, duration, duration, 0, 0),
+            (duration, halfway, duration, 0, 0),
+            (duration, halfway - 1, duration, 0, 0),
+            (duration - tenSeconds, halfway, duration, 0, 0),
+            (duration - tenSeconds - 1, halfway, duration, 0, 0),
+            (halfway, (long)(duration * 0.9), duration, 0, 0),
+            (duration, null, duration, 0, 0),
+            (duration, null, duration, halfway, 0),
+            (duration, null, duration, halfway + 1, 0),
+            (duration, null, duration, 0, 1),
+            (duration - tenSeconds - 1, null, duration, 0, 0),
+            (duration, null, duration, null, 0),
+            (duration, null, null, 0, 0),
+            (duration, null, 0, 0, 0),
+            (null, duration, duration, 0, 0),
+        };
+
+        var path = Path.Combine(_directory, "jellyfin-harmonie.db");
+        var beforeMigration = new IHarmonieDatabaseMigration[]
+        {
+            new Migration001ListeningActivity(),
+            new Migration002RecommendationMetricsIndex(),
+            new Migration003PlaybackSessionCheckpoints(),
+        };
+        var database = new HarmonieDatabase(path, beforeMigration);
+        database.Initialize();
+
+        using (var connection = database.OpenConnection())
+        {
+            for (var i = 0; i < rows.Length; i++)
+            {
+                var row = rows[i];
+                using var command = connection.CreateCommand();
+                command.CommandText = """
+                    INSERT INTO playback_events (
+                        user_id, item_id, stopped_utc, start_position_ticks,
+                        end_position_ticks, active_listen_ticks,
+                        seek_forward_count, seek_backward_count, pause_count,
+                        is_early_skip, duration_ticks, played_to_completion,
+                        counted_as_play)
+                    VALUES (
+                        'user', $item_id, '2026-08-18T10:00:00Z', $start,
+                        $end, $active, $seek, 0, 0, 0, $duration, 0,
+                        $seeded);
+                    """;
+                command.Parameters.AddWithValue("$item_id", $"item-{i}");
+                command.Parameters.AddWithValue("$start", (object?)row.Start ?? DBNull.Value);
+                command.Parameters.AddWithValue("$end", (object?)row.End ?? DBNull.Value);
+                command.Parameters.AddWithValue("$active", (object?)row.Active ?? DBNull.Value);
+                command.Parameters.AddWithValue("$seek", row.Seek);
+                command.Parameters.AddWithValue("$duration", (object?)row.Duration ?? DBNull.Value);
+
+                // Seeded with the opposite of the expected value where possible,
+                // so a migration that skipped the row fails the assertion.
+                command.Parameters.AddWithValue("$seeded", i % 2);
+                command.ExecuteNonQuery();
+            }
+        }
+
+        var upgraded = new HarmonieDatabase(path);
+        upgraded.Initialize();
+
+        using var upgradedConnection = upgraded.OpenConnection();
+        using var resultCommand = upgradedConnection.CreateCommand();
+        resultCommand.CommandText = "SELECT item_id, counted_as_play FROM playback_events ORDER BY id;";
+        using var reader = resultCommand.ExecuteReader();
+        var checked_ = 0;
+        while (reader.Read())
+        {
+            var row = rows[checked_];
+            var expected = PlaybackSessionAccumulator.IsCountedAsPlay(
+                row.End,
+                row.Active,
+                row.Duration,
+                row.Start,
+                row.Seek)
+                ? 1L
+                : 0L;
+            var actual = reader.GetInt64(1);
+            Assert.True(
+                expected == actual,
+                $"{reader.GetString(0)}: SQL gave {actual}, IsCountedAsPlay gave {expected}");
+            checked_++;
+        }
+
+        Assert.Equal(rows.Length, checked_);
+        Assert.Equal(4, upgraded.SchemaVersion);
     }
 
     private sealed class RecordingMigration : IHarmonieDatabaseMigration

--- a/tests/Jellyfin.Plugin.Harmonie.Tests/ListeningActivityStoreTests.cs
+++ b/tests/Jellyfin.Plugin.Harmonie.Tests/ListeningActivityStoreTests.cs
@@ -42,7 +42,7 @@ public sealed class ListeningActivityStoreTests : IDisposable
 
         Assert.True(first);
         Assert.False(second);
-        Assert.Equal(3, status.SchemaVersion);
+        Assert.Equal(4, status.SchemaVersion);
         Assert.False(store.IsBootstrapRequired());
 
         using var connection = new HarmonieDatabase(
@@ -79,7 +79,7 @@ public sealed class ListeningActivityStoreTests : IDisposable
 
         var status = store.GetStatus();
 
-        Assert.Equal(3, status.SchemaVersion);
+        Assert.Equal(4, status.SchemaVersion);
         Assert.True(status.SizeBytes > 0);
         Assert.Equal(Path.GetFullPath(Path.Combine(_directory, "jellyfin-harmonie.db")), status.DatabasePath);
 

--- a/tests/Jellyfin.Plugin.Harmonie.Tests/ListeningActivityTrackerTests.cs
+++ b/tests/Jellyfin.Plugin.Harmonie.Tests/ListeningActivityTrackerTests.cs
@@ -80,7 +80,7 @@ public class ListeningActivityTrackerTests
     }
 
     [Fact]
-    public void Playback_stop_uses_the_derived_completion_value()
+    public void Playback_stop_does_not_use_jellyfin_completion_as_play_count()
     {
         var user = User("listener");
         var item = new Audio
@@ -111,6 +111,44 @@ public class ListeningActivityTrackerTests
             eventArgs,
             summary,
             DateTimeOffset.Parse("2026-08-16T10:02:00Z")));
+
+        Assert.False(activity.PlayedToCompletion);
+        Assert.False(activity.CountedAsPlay);
+    }
+
+    [Fact]
+    public void Playback_stop_counts_a_qualified_listen_when_jellyfin_does_not()
+    {
+        var user = User("listener");
+        var duration = TimeSpan.FromMinutes(4).Ticks;
+        var listened = TimeSpan.FromSeconds(220).Ticks;
+        var eventArgs = new PlaybackStopEventArgs
+        {
+            Item = new Audio
+            {
+                Id = Guid.NewGuid(),
+                RunTimeTicks = duration,
+            },
+            Users = new List<User> { user },
+            PlaybackPositionTicks = listened,
+            PlayedToCompletion = false,
+        };
+        var summary = new PlaybackSessionSummary(
+            DateTimeOffset.Parse("2026-08-16T10:00:00Z"),
+            StartPositionTicks: 0,
+            EndPositionTicks: listened,
+            MaxPositionTicks: listened,
+            ActiveListenTicks: listened,
+            SeekForwardCount: 0,
+            SeekBackwardCount: 0,
+            PauseCount: 0,
+            PlayedToCompletion: false,
+            IsEarlySkip: false);
+
+        var activity = Assert.Single(ListeningActivityTracker.CreateActivities(
+            eventArgs,
+            summary,
+            DateTimeOffset.Parse("2026-08-16T10:03:40Z")));
 
         Assert.False(activity.PlayedToCompletion);
         Assert.True(activity.CountedAsPlay);

--- a/tests/Jellyfin.Plugin.Harmonie.Tests/ListeningActivityTrackerTests.cs
+++ b/tests/Jellyfin.Plugin.Harmonie.Tests/ListeningActivityTrackerTests.cs
@@ -288,6 +288,84 @@ public class ListeningActivityTrackerTests
         Assert.Contains("recent", sessions.Keys);
     }
 
+    /// <summary>
+    /// A client that reports progress without a start leaves active listening
+    /// unmeasurable. The listen must still count when playback ran from the
+    /// first observed position through to the end.
+    /// </summary>
+    [Fact]
+    public void Playback_stop_counts_a_progress_only_listen_that_reached_the_end()
+    {
+        var user = User("listener");
+        var duration = TimeSpan.FromMinutes(4).Ticks;
+        var eventArgs = new PlaybackStopEventArgs
+        {
+            Item = new Audio
+            {
+                Id = Guid.NewGuid(),
+                RunTimeTicks = duration,
+            },
+            Users = new List<User> { user },
+            PlaybackPositionTicks = duration,
+            PlayedToCompletion = false,
+        };
+        var summary = new PlaybackSessionSummary(
+            StartedUtc: null,
+            StartPositionTicks: TimeSpan.FromSeconds(12).Ticks,
+            EndPositionTicks: duration,
+            MaxPositionTicks: duration,
+            ActiveListenTicks: null,
+            SeekForwardCount: 0,
+            SeekBackwardCount: 0,
+            PauseCount: 0,
+            PlayedToCompletion: false,
+            IsEarlySkip: false);
+
+        var activity = Assert.Single(ListeningActivityTracker.CreateActivities(
+            eventArgs,
+            summary,
+            DateTimeOffset.Parse("2026-08-16T10:04:00Z")));
+
+        Assert.Null(activity.ActiveListenTicks);
+        Assert.True(activity.CountedAsPlay);
+    }
+
+    [Fact]
+    public void Playback_stop_does_not_count_a_progress_only_listen_that_jumped_ahead()
+    {
+        var user = User("listener");
+        var duration = TimeSpan.FromMinutes(4).Ticks;
+        var eventArgs = new PlaybackStopEventArgs
+        {
+            Item = new Audio
+            {
+                Id = Guid.NewGuid(),
+                RunTimeTicks = duration,
+            },
+            Users = new List<User> { user },
+            PlaybackPositionTicks = duration,
+            PlayedToCompletion = true,
+        };
+        var summary = new PlaybackSessionSummary(
+            StartedUtc: null,
+            StartPositionTicks: 0,
+            EndPositionTicks: duration,
+            MaxPositionTicks: duration,
+            ActiveListenTicks: null,
+            SeekForwardCount: 1,
+            SeekBackwardCount: 0,
+            PauseCount: 0,
+            PlayedToCompletion: false,
+            IsEarlySkip: false);
+
+        var activity = Assert.Single(ListeningActivityTracker.CreateActivities(
+            eventArgs,
+            summary,
+            DateTimeOffset.Parse("2026-08-16T10:00:30Z")));
+
+        Assert.False(activity.CountedAsPlay);
+    }
+
     private static User User(string name)
         => new(name, "test-auth", "test-reset") { Id = Guid.NewGuid() };
 }

--- a/tests/Jellyfin.Plugin.Harmonie.Tests/PlaybackSessionAccumulatorTests.cs
+++ b/tests/Jellyfin.Plugin.Harmonie.Tests/PlaybackSessionAccumulatorTests.cs
@@ -222,6 +222,135 @@ public sealed class PlaybackSessionAccumulatorTests
         Assert.True(activity.IsEarlySkip);
     }
 
+    /// <summary>
+    /// A client that reports progress without a start leaves active listening
+    /// unmeasurable. The listen still counts when playback ran from the first
+    /// observed position through to the end without jumping ahead.
+    /// </summary>
+    [Fact]
+    public void Progress_only_session_that_runs_to_the_end_counts_as_a_play()
+    {
+        var duration = TimeSpan.FromMinutes(3);
+        var observed = DateTimeOffset.Parse("2026-08-16T10:00:00Z");
+        var session = PlaybackSessionAccumulator.FromProgress(
+            observed,
+            TimeSpan.FromSeconds(20).Ticks,
+            isPaused: false);
+
+        var summary = session.Finish(
+            observed.Add(duration).AddSeconds(-20),
+            duration.Ticks,
+            duration.Ticks);
+
+        Assert.Null(summary.ActiveListenTicks);
+        Assert.True(PlaybackSessionAccumulator.IsCountedAsPlay(
+            summary.EndPositionTicks,
+            summary.ActiveListenTicks,
+            duration.Ticks,
+            summary.StartPositionTicks,
+            summary.SeekForwardCount));
+    }
+
+    [Fact]
+    public void Progress_only_session_that_jumps_ahead_does_not_count()
+    {
+        var duration = TimeSpan.FromMinutes(3);
+        var observed = DateTimeOffset.Parse("2026-08-16T10:00:00Z");
+        var session = PlaybackSessionAccumulator.FromProgress(
+            observed,
+            TimeSpan.FromSeconds(20).Ticks,
+            isPaused: false);
+        session.Observe(
+            observed.AddSeconds(5),
+            TimeSpan.FromSeconds(150).Ticks,
+            isPaused: false);
+
+        var summary = session.Finish(
+            observed.AddSeconds(35),
+            duration.Ticks,
+            duration.Ticks);
+
+        Assert.Equal(1, summary.SeekForwardCount);
+        Assert.False(PlaybackSessionAccumulator.IsCountedAsPlay(
+            summary.EndPositionTicks,
+            summary.ActiveListenTicks,
+            duration.Ticks,
+            summary.StartPositionTicks,
+            summary.SeekForwardCount));
+    }
+
+    /// <summary>
+    /// Joining past the halfway mark leaves less than half the track played,
+    /// which is the floor the measured rule applies.
+    /// </summary>
+    [Fact]
+    public void Progress_only_session_joined_past_halfway_does_not_count()
+    {
+        var duration = TimeSpan.FromMinutes(4);
+
+        Assert.False(PlaybackSessionAccumulator.IsCountedAsPlay(
+            endPositionTicks: duration.Ticks,
+            activeListenTicks: null,
+            durationTicks: duration.Ticks,
+            startPositionTicks: TimeSpan.FromMinutes(2).Add(TimeSpan.FromSeconds(1)).Ticks,
+            seekForwardCount: 0));
+
+        Assert.True(PlaybackSessionAccumulator.IsCountedAsPlay(
+            endPositionTicks: duration.Ticks,
+            activeListenTicks: null,
+            durationTicks: duration.Ticks,
+            startPositionTicks: TimeSpan.FromMinutes(2).Ticks,
+            seekForwardCount: 0));
+    }
+
+    [Fact]
+    public void Progress_only_session_stopped_short_of_the_end_does_not_count()
+    {
+        var duration = TimeSpan.FromMinutes(4);
+
+        Assert.False(PlaybackSessionAccumulator.IsCountedAsPlay(
+            endPositionTicks: duration.Ticks - TimeSpan.FromSeconds(11).Ticks,
+            activeListenTicks: null,
+            durationTicks: duration.Ticks,
+            startPositionTicks: 0,
+            seekForwardCount: 0));
+    }
+
+    /// <summary>
+    /// A progress-only session recovered from its checkpoint follows the same
+    /// rule: the checkpoint carries the join position and the seek counts.
+    /// </summary>
+    [Fact]
+    public void Recovered_progress_only_session_counts_as_a_play()
+    {
+        var duration = TimeSpan.FromMinutes(3);
+        var observedAt = DateTimeOffset.Parse("2026-08-16T10:00:00Z");
+        var checkpoint = new PlaybackSessionCheckpoint(
+            SessionKey: "session-1",
+            UserId: Guid.NewGuid(),
+            ItemId: Guid.NewGuid(),
+            StartedUtc: null,
+            LastObservedUtc: observedAt.Add(duration),
+            StartPositionTicks: TimeSpan.FromSeconds(15).Ticks,
+            EndPositionTicks: duration.Ticks,
+            MaxPositionTicks: duration.Ticks,
+            ActiveListenTicks: null,
+            SeekForwardCount: 0,
+            SeekBackwardCount: 0,
+            PauseCount: 0,
+            IsPaused: false,
+            DurationTicks: duration.Ticks,
+            PlaySessionId: "play-1",
+            ClientName: "Finamp",
+            DeviceId: "phone");
+
+        var activity = PlaybackSessionAccumulator.Recover(checkpoint);
+
+        Assert.True(activity.CountedAsPlay);
+        Assert.False(activity.PlayedToCompletion);
+        Assert.False(activity.IsEarlySkip);
+    }
+
     [Fact]
     public void Live_stop_keeps_the_tight_completion_margin_on_short_tracks()
     {


### PR DESCRIPTION
`counted_as_play` meant two different things: Jellyfin's completion flag on live stops, Harmonie's derived rule elsewhere. This change applies Harmonie's rule everywhere: at least half the track actively listened and either ending within 10s of the end or 90% listened, falling back to positional evidence (ran to the end from the join point, no forward seeks, joined by halfway) for sessions where no start event was seen and listening time cannot be measured. 

The migration reclassifies existing rows under the same rule, so play counts shift once on upgrade.